### PR TITLE
I2648

### DIFF
--- a/src/Filter.ts
+++ b/src/Filter.ts
@@ -59,7 +59,6 @@ export class ListFilter extends Filter {
 
 export class CountryFilter extends ListFilter {
     selectCountryGroup(selectedGroup: string) {
-console.log(pineCountries)
         switch(selectedGroup) {
             case "all":
                 this.selectedOptions(this.options());

--- a/src/Filter.ts
+++ b/src/Filter.ts
@@ -58,8 +58,8 @@ export class ListFilter extends Filter {
 }
 
 export class CountryFilter extends ListFilter {
-
     selectCountryGroup(selectedGroup: string) {
+console.log(pineCountries)
         switch(selectedGroup) {
             case "all":
                 this.selectedOptions(this.options());
@@ -68,13 +68,13 @@ export class CountryFilter extends ListFilter {
                 this.selectedOptions([]);
                 break;
             case "pine":
-                this.selectedOptions(pineCountries);
+                this.selectedOptions([...pineCountries]);
                 break;
             case "gavi73":
-                this.selectedOptions(gavi73);
+                this.selectedOptions([...gavi73]);
                 break;
             case "gavi69":
-                this.selectedOptions(gavi69);
+                this.selectedOptions([...gavi69]);
                 break;
             default:
                 this.selectedOptions([]);


### PR DESCRIPTION
This bug occurred when the knockout functions ignored the typescript const bindings and modified what should be const arrays.

To get around this I clone the const array and pass the clone to the knockout function. The clone is modified by the knockout call but the original array is left unchanged.

Is there a more idiomatic javascript way of doing this?