### PR TITLE
Fix ordering bug by creating new object with new reference

### DIFF
--- a/src/DataFilterer.ts
+++ b/src/DataFilterer.ts
@@ -112,9 +112,6 @@ export class DataFilterer {
         const aggVars_top: any[] = [...this.getUniqueVariables(-1, filterOptions.disagg, top, filteredData_top)];
         const dataByAggregate_top = this.groupDataByDisaggAndThenCompare("year", filterOptions.disagg, aggVars_top, filteredData_top);
 
-
-        
-
         let datasets: FilteredRow[] = [];
         for (let aggVar of aggVars_top) {
             let summedMetricForDisagg: number[] = this.reduceSummary(dataByAggregate_top,

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -183,7 +183,7 @@ class DataVisModel {
 
     updateXAxisOptions() {
         // refilter the data
-        let chartOptions = this.chartOptions();
+        let chartOptions = { ...this.chartOptions() };
         chartOptions.maxPlot = -1;
 
         const filteredData = new DataFilterer().filterData(chartOptions, impactData, plotColours);

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -183,8 +183,7 @@ class DataVisModel {
 
     updateXAxisOptions() {
         // refilter the data
-        let chartOptions = { ...this.chartOptions() };
-        chartOptions.maxPlot = -1;
+        const chartOptions = {...this.chartOptions(), maxPlot: -1};
 
         const filteredData = new DataFilterer().filterData(chartOptions, impactData, plotColours);
         this.compareNames(filteredData.compVars);


### PR DESCRIPTION
This is similar to https://github.com/vimc/ts_data_visualisation/pull/22.

i feel like in these PRs I'm working against the language to get it to do what I want.

In this case we need to re-filterer the data when some of the sidebar parameters have changed, but we want to count all the x-axis options (which is why `maxPlot` is set to -1) with everything else in `chartOptions` kept the same. It feels there should be a better way of doing this rather than cloning the whole object with jquery call.