### PR TITLE
I2713 Implement filtering on support type

### DIFF
--- a/scripts/generateTestData.js
+++ b/scripts/generateTestData.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-import {countries, touchstones, activityTypes, diseases} from "../src/Data.ts"
+import {countries, touchstones, activityTypes, diseases, supportTypes} from "../src/Data.ts"
 
 for (let i in touchstones) {
     var tsName = touchstones[i];
@@ -35,15 +35,16 @@ function generateData(touchstone) {
         countries.flatMap((c) =>
             diseases.flatMap((d) =>
                 diseaseVaccineLookup[d].flatMap((v) =>
-                    activityTypes.flatMap((a) =>
-                        [2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020]
-                            .flatMap((y) => {
+                    supportTypes.flatMap((s) =>
+                        activityTypes.flatMap((a) =>
+                            [2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020]
+                                .flatMap((y) => {
                                     return {
                                         "touchstone": touchstone,
                                         "disease": d,
                                         "is_focal": true,
                                         "activity_type": a,
-                                        "support_type": "gavi",
+                                        "support_type": s,
                                         "vaccine": v,
                                         "gavi73": true,
                                         "country": c,
@@ -64,6 +65,7 @@ function generateData(touchstone) {
                             )
                         )
                     )
+                )
             )
         );
 

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -37,9 +37,11 @@ export const vaccines = ["HepB", "HepB_BD", "Hib3", "HPV", "JE", "MCV1", "MCV2",
 export const activityTypes = ["routine", "campaign", "combined"];
 
 export const plottingVariables = ["year", "country", "continent", "region",
-    "cofinance_status_2018", "activity_type", "disease", "vaccine", "touchstone"];
+    "cofinance_status_2018", "activity_type", "disease", "vaccine", "touchstone", "support_type"];
 
 export const touchstones = ["201710gavi", "201710gavi-201807wue", "201510gavi",
                             "201310gavi-201807wue", "201310gavi",
                             "201310gavi-201403gavi", "201510gavi-201807wue",
                             "201210gavi-201807wue", "201210gavi-201303gavi"];
+
+export const supportTypes = ["gavi", "other"];

--- a/src/DataFilterer.ts
+++ b/src/DataFilterer.ts
@@ -20,6 +20,7 @@ export interface DataFiltererOptions {
     selectedCountries:   Array<string>;
     selectedVaccines:    Array<string>;
     selectedTouchstones: Array<string>;
+    supportType:         Array<string>;
     cumulative:          boolean;
     timeSeries:          boolean;
 }
@@ -253,8 +254,8 @@ export class DataFilterer {
         return impactData.filter((row) => row.is_focal === isFocal );
     }
 
-    private filterBySupport(impactData: ImpactDataRow[], supportType: string): ImpactDataRow[] {
-        return impactData.filter((row) => row.support_type === supportType );
+    private filterBySupport(impactData: ImpactDataRow[], supportType: string[]): ImpactDataRow[] {
+        return impactData.filter((row) => supportType.indexOf(row.support_type) > -1 );
     }
 
     private filterByTouchstone(impactData: ImpactDataRow[], touchStone: string[]): ImpactDataRow[] {
@@ -281,7 +282,7 @@ export class DataFilterer {
     private filterByAll(filterOptions: DataFiltererOptions,
                         impactData: ImpactDataRow[]): ImpactDataRow[] {
         let filtData = this.filterByFocality(impactData, true); // filter focal model
-        filtData = this.filterBySupport(filtData, "gavi"); // filter so that support = gavi
+        filtData = this.filterBySupport(filtData, filterOptions.supportType); // filter so that support = gavi
         filtData = this.filterByYear(filtData, filterOptions.yearLow, filterOptions.yearHigh); // filter by years
         filtData = this.filterByTouchstone(filtData, filterOptions.selectedTouchstones); // filter by touchstone
         filtData = this.filterByActivityType(filtData, filterOptions.activityTypes); // filter by activity type

--- a/src/PlotColours.ts
+++ b/src/PlotColours.ts
@@ -188,6 +188,9 @@ export const plotColours: { [vaccine: string]: string } = {
     "201210gavi-201807wue":  "#ff0000",
     "201210gavi-201303gavi": "#9400d3",
     "201310gavi-201403gavi": "#808000",
+    // support Types
+    "gavi":  "#0000ff",
+    "other": "#8b0000",
 };
 
 export const niceColours = {

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -16,7 +16,7 @@ import 'bootstrap/dist/css/bootstrap.css';
 import "select2/dist/css/select2.min.css"
 import {appendToDataSet, DataSetUpdate} from "./AppendDataSets";
 import {CustomChartOptions, impactChartConfig, timeSeriesChartConfig} from "./Chart";
-import {activityTypes, countries, diseases, plottingVariables, touchstones, vaccines} from "./Data";
+import {activityTypes, countries, diseases, plottingVariables, supportTypes, touchstones, vaccines} from "./Data";
 
 // stuff to handle the data set being split into multiple files
 const initTouchstone: string = "201710gavi-201807wue";
@@ -87,6 +87,12 @@ class DataVisModel {
         name: "Touchstone",
         options: touchstones,
         selected: [initTouchstone],
+    }));
+
+    private supportFilter = ko.observable(new ListFilter({
+        name: "Support type",
+        options: supportTypes,
+        selected: ["gavi"],
     }));
 
     private xAxisOptions = plottingVariables;
@@ -185,6 +191,7 @@ class DataVisModel {
             selectedCountries: this.countryFilter().selectedOptions(), // which countries do we care about
             selectedTouchstones: this.touchstoneFilter().selectedOptions(), // which touchstones do we care about
             selectedVaccines: this.diseaseFilter().selectedOptions(), // which vaccines do we care about
+            supportType: this.supportFilter().selectedOptions(),
             timeSeries: this.currentPlot() === "Time series",
             yAxisTitle: this.yAxisTitle(),
             yearHigh: this.yearFilter().selectedHigh(), // upper bound on yeat
@@ -225,6 +232,9 @@ class DataVisModel {
             this.updateXAxisOptions();
         });
         this.diseaseFilter().selectedOptions.subscribe(() => {
+            this.updateXAxisOptions();
+        });
+        this.supportFilter().selectedOptions.subscribe(() => {
             this.updateXAxisOptions();
         });
 

--- a/src/index.html
+++ b/src/index.html
@@ -214,6 +214,25 @@
                 </div>
             </div>
         </li>
+        <li class="nav-item" data-bind="with: supportFilter">
+            <a class="nav-link nav-parent"
+               href="#"
+               data-bind="text: name,
+                              css: { active: isOpen },
+                              click: toggleOpen"></a>
+
+            <div class="filter clearfix" data-bind="css: {in: isOpen}, foreach: options">
+                <div class="nav-item nav-option">
+                    <div class="nav-link">
+                        <label data-bind="attr: {for: $data}">
+                            <input type="checkbox"
+                                   data-bind="attr: { value: $data, id: $data }, checked: $parent.selectedOptions">
+                            <span data-bind="text: $data"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </li>
     </ul>
 </div>
 


### PR DESCRIPTION
This PR adds a filter that allow filtering on support type.
At present the only support types are `gavi` and `other`.

We might want to add a warning message when both are selected. I'll check with the science team if there is a sane reason for selecting 'both'.