### PR TITLE
I2703 Add functionality for dynamically adding colours

### DIFF
--- a/src/DataFilterer.ts
+++ b/src/DataFilterer.ts
@@ -1,5 +1,6 @@
 import {FilteredRow} from "./FilteredRow";
 import {ImpactDataRow} from "./ImpactDataRow";
+import {niceColours} from "./PlotColours";
 
 interface ImpactDataByCountry {
     [country: string]: ImpactDataRow[];
@@ -81,6 +82,8 @@ export class DataFilterer {
                     .reduce((a: number[], x: number, i: number) => [...a, (+x) + (a[i - 1] || 0)], []);
             }
             // code here to convert sum to average
+
+            this.getColour(aggVar, plotColours, niceColours);
 
             if (filterOptions.timeSeries) {
                 const fRow: FilteredRow = { backgroundColor: "transparent",
@@ -171,6 +174,8 @@ export class DataFilterer {
                 summedMetricForDisagg = summedMetricForDisagg
                     .reduce((a: number[], x: number, i: number) => [...a, (+x) + (a[i - 1] || 0)], []);
             }
+
+            this.getColour(aggVar, plotColours, niceColours);
 
             const fRow: FilteredRow = { backgroundColor: "transparent",
                                         borderColor: plotColours[aggVar],
@@ -328,5 +333,23 @@ export class DataFilterer {
             }
         }, this);
         return summedMetricForDisagg;
+    }
+
+    // This is a slightly hacky way to dynamically assign colours to keys that don't have them
+    // This should never be hit, if it is we should add the missing colours to ./PlotColours.ts
+    private getColour(key: string, colourDict: { [key: string]: string },
+                      niceColours:{ [key: string]: string }): void {
+        // check if this key is in the dictionary...
+        if (!(key in colourDict)) { //...if not try to find a new colour
+            console.log("Warning: " + key + " does not have a default colour");
+            // convert niceColours to an array
+            const extraCNames = Object.keys(niceColours);
+            // pick one at random
+            let colourName: string = extraCNames[Math.floor(Math.random()*extraCNames.length)];
+            // add it to the colourDictionary
+            $.extend(colourDict, { [key]: niceColours[colourName]});
+            // delete it from the list of available colours
+            delete niceColours[colourName];
+        }
     }
 }

--- a/src/DataFilterer.ts
+++ b/src/DataFilterer.ts
@@ -342,14 +342,22 @@ export class DataFilterer {
         // check if this key is in the dictionary...
         if (!(key in colourDict)) { //...if not try to find a new colour
             console.log("Warning: " + key + " does not have a default colour");
-            // convert niceColours to an array
-            const extraCNames = Object.keys(niceColours);
-            // pick one at random
-            let colourName: string = extraCNames[Math.floor(Math.random()*extraCNames.length)];
-            // add it to the colourDictionary
-            $.extend(colourDict, { [key]: niceColours[colourName]});
-            // delete it from the list of available colours
-            delete niceColours[colourName];
+            // make sure we have some nice colours to add
+            if (Object.keys(niceColours).length > 0) {
+                // convert niceColours to an array
+                const extraCNames = Object.keys(niceColours);
+                // pick one at random
+                let colourName: string = extraCNames[Math.floor(Math.random()*extraCNames.length)];
+                // add it to the colourDictionary
+                $.extend(colourDict, { [key]: niceColours[colourName]});
+                // delete it from the list of available colours
+                delete niceColours[colourName];
+            } else {
+                console.log("Additional warning: We have run out of nice colours");
+                // if there are no colours, so add a neutral grey colour so that it
+                // it should be obvious when we've run out of colours.
+                $.extend(colourDict, { [key]: "#999999"});
+            }
         }
     }
 }

--- a/src/PlotColours.ts
+++ b/src/PlotColours.ts
@@ -1,4 +1,5 @@
-export const plotColours: { [vaccine: string]: string } = {
+// This is not const as we might append colours to it at run time
+export let plotColours: { [vaccine: string]: string } = {
     // disease / vaccine colours
     "HPV":     "#BEBADA",
     "HepB":    "#8DD3C7",
@@ -58,9 +59,9 @@ export const plotColours: { [vaccine: string]: string } = {
     "Europe":   "#003399",
     "Oceania":  "#a267ff",
     // gavi cofin status
-    "Graduating": "#90ee90",
-    "Intermediate": "#ffd700",
-    "Low-Income": "#8B0000",
+    "ATP": "#90ee90",
+    "ISF": "#ffd700",
+    "PTP": "#8B0000",
     // regions
     "Southern Asia":      "#FF8C00",
     "Middle Africa":      "#00873a",
@@ -190,7 +191,7 @@ export const plotColours: { [vaccine: string]: string } = {
     "201310gavi-201403gavi": "#808000",
 };
 
-export const niceColours = {
+export let niceColours = {
     aqua:           "#00ffff",
     azure:          "#f0ffff",
     beige:          "#f5f5dc",


### PR DESCRIPTION
Some of the names changed in the data set we use from the science team.
This lead to colours not being assigned in the plot.
This PR changes the dictionary to the new set, and adds functionality that ensures names without colours have colours assigned at run time.
There are only 20 'extra' colours to assign so this might blow up horribly if there are more missing.