### PR TITLE
Vimc 3185

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,31 +5,18 @@
 
 The typescript / knockout implementation of the interactive reporting app.
 
-Compiling this is somewhat complicated as it relies on a large 100+MB data file that we don't want to put into git.
+Compiling this is somewhat complicated as it relies on a multiple large data
+files that we don't want to put into git.
 
-The data set is `201710gavi_summary.rds` from the Montagu report `native-201710gavi-method2`.
+The data file are `interim-update-201907wue_summary.rds` from the Montagu report
+`modup2-201907` and, `life_time_impact.rds` and `cross_sectional_impact.rds`
+from `internal-2018-201710gavi-impact-estimates`.
 
-To compile this report we need to 
-* grab that data file,
-* convert it to a JSON file,
-* prepend the file with `const impactData = ` and turn the file into a javascript file
-* move the `.js` into `data/`.
+In addition to the data files we also need some _dictionary_ files containing
+_e.g._ country and vaccine names.
 
-A simple R script to create this file is:
-```
-temp_data <- readRDS("201710gavi_summary.rds")
-
-# save the impact data a json file
-jsonlite::write_json(temp_data, "temporary.json", pretty = TRUE, na = "string")
-
-# we need the json file to be a javascript file
-# prepended with 'const impactdata = '
-system("echo 'const impactData = ' > impactData.js")
-system("cat temporary.json >> impactData.js")
-
-# remove the json file
-file.remove("temporary.json")
-```
+The process of creating these files for the app is carried out in the montagu
+report `internal-2018-interactive-plotting`.
 
 # Local development
 
@@ -41,14 +28,15 @@ This method is ideal for UI development where the data does not matter at all.
 1. `cd out && python -m SimpleHTTPServer` to serve the compiled files.
 1. Visit localhost:8000 in your browser to view the app.
 
-Note that the fake data only contains points for years 2014 - 2020 and for the most 
-recent 3 touchstones.
+Note that the fake data only contains points for years 2014 - 2020 and for the
+most recent 3 touchstones.
 
 ## Using realistic data:
 Useful if you want data that resembles the real data set, but still want
 local development to be a bit quicker.
 1. Grab the real data set by downloading the relevant artefact from the
-reporting portal and copying it into this repo's `data` directory.
+reporting portal (`https://montagu.vaccineimpact.org/reports/report/internal-2018-interactive-plotting/XXXXXXXX-XXXXXX-XXXXXXXX`)
+and copying it into this repo's `data` directory.
 1. `./scripts/thinData`.
 1. `npm install`
 1. `npm run build-dev` or `npm run build-dev-watch`
@@ -58,7 +46,10 @@ reporting portal and copying it into this repo's `data` directory.
 ## Using real data:
 This will make development slow, but will give you the most accurate impression
 of the app in production.
-1. Grab the real data set as above but this time put it straight into `data/test`.
+1. Grab the real data file by downloading the relevant file from the relevant
+report on the reporting portal
+(`https://montagu.vaccineimpact.org/reports/report/internal-2018-interactive-plotting/XXXXXXXX-XXXXXX-XXXXXXXX`). 
+Copy the files to `data/test`.
 1. `npm install`
 1. `npm run build-dev` or `npm run build-dev-watch`
 1. `cd out && python -m SimpleHTTPServer` to serve the compiled files.

--- a/scripts/generateTestData.js
+++ b/scripts/generateTestData.js
@@ -7,14 +7,29 @@ import {countryDict, countries, touchstones, activityTypes, diseases, diseaseVac
 // Impact data
 for (let i in touchstones) {
     var tsName = touchstones[i];
-    var fileName = "data/test/impactData_" + tsName + ".json";
-    fs.writeFile(fileName, generateData(tsName), function (err) {
-    if (err) {
-        return console.log(err);
-    }
+    var fileName0 = "data/test/impactData_" + tsName + "_method_0.json";
+    fs.writeFile(fileName0, generateData(tsName), function (err) {
+        if (err) {
+            return console.log(err);
+        }
+    });
 
-    console.log("Fake data saved to " + fileName)
-});
+    var fileName1 = "data/test/impactData_" + tsName + "_method_1.json";
+        fs.writeFile(fileName1, generateData(tsName), function (err) {
+        if (err) {
+            return console.log(err);
+        }
+    });
+
+    var fileName2 = "data/test/impactData_" + tsName + "_method_2.json";
+    fs.writeFile(fileName2, generateData(tsName), function (err) {
+        if (err) {
+            return console.log(err);
+        };
+    })
+    console.log("Fake data saved to " + fileName0);
+    console.log("Fake data saved to " + fileName1);
+    console.log("Fake data saved to " + fileName2);
 }
 
 function writeToFile(path, data) {

--- a/src/AppendDataSets.ts
+++ b/src/AppendDataSets.ts
@@ -17,8 +17,9 @@ export interface DataSet {
 export function getDataSet(name: string,
                            sets: DataSet[]): DataSet {
     const ds = sets.find((x) => x.name === name);
-    if (ds === null) {
-        console.log("No dataset with this name");
+    if (ds === undefined) {
+        console.log("No dataset named " + name);
+        return null;
     }
     return ds;
 }
@@ -29,6 +30,9 @@ export function appendToDataSet(toAdd: string[],
                                 setPrev: boolean = false,
                                 ) {
     const ds = getDataSet(appendTo, dataSets);
+    if (ds === null) {
+        return;
+    }
     // for each selected touchstone...
     for (const touchstone of toAdd) {
         // ...check if we've already added this data set...

--- a/src/AppendDataSets.ts
+++ b/src/AppendDataSets.ts
@@ -13,39 +13,18 @@ export interface DataSet {
     seen: string[]
 }
 
-export function appendToDataSet(touchstones: string[],
-                                seenDataSets: string[],
-                                curDataset: ImpactDataRow[]): DataSetUpdate {
-    // for each selected touchstone...
-    for (const touchstone of touchstones) {
-        // ...check if we've already added this data set...
-        if (seenDataSets.indexOf(touchstone) === -1) {
-            // ...if not add it
-            // WARNING This file needs to be in same directory otherwise
-            // it will break the report on the portal
-            const filename = "./impactData_" + touchstone + "_method_2.json";
-            const newData: ImpactDataRow[] =
-                    loadObjectFromJSONFile(filename);
-
-            curDataset = curDataset.concat(newData);
-            seenDataSets.push(touchstone);
-        }
+export function getDataSet(name: string,
+                           sets: DataSet[]): ImpactDataRow[] {
+    const ds = sets.find(x => { return x.name == name } )
+    if (ds === null) {
+        console.log("WTF!")
     }
-    const update = {
-        newDataSet: curDataset,
-        newSeenList: seenDataSets,
-    };
-    return update;
+    return ds.data
 }
 
-export function getSingleDataSet(filename: string) {
-    const newData: ImpactDataRow[] = loadObjectFromJSONFile(filename);
-    return newData;
-}
-
-export function appendToDataSet2(toAdd: string[],
-                                 appendTo: string,
-                                 dataSets: DataSet[],
+export function appendToDataSet(toAdd: string[],
+                                appendTo: string,
+                                dataSets: DataSet[],
                                  ){
     const ds = dataSets.find(x => { return x.name == appendTo } )
     // for each selected touchstone...

--- a/src/AppendDataSets.ts
+++ b/src/AppendDataSets.ts
@@ -10,7 +10,8 @@ export interface DataSetUpdate {
 export interface DataSet {
     name: string,
     data: ImpactDataRow[],
-    seen: string[]
+    seen: string[],
+    prev: string[]
 }
 
 export function getDataSet(name: string,
@@ -25,7 +26,8 @@ export function getDataSet(name: string,
 export function appendToDataSet(toAdd: string[],
                                 appendTo: string,
                                 dataSets: DataSet[],
-                                 ){
+                                setPrev: boolean = false
+                                ){
     const ds = dataSets.find(x => { return x.name == appendTo } )
     // for each selected touchstone...
     for (const touchstone of toAdd) {
@@ -41,5 +43,9 @@ export function appendToDataSet(toAdd: string[],
             ds.data = ds.data.concat(newData);
             ds.seen.push(touchstone);
         }
+    }
+
+    if (setPrev) {
+        ds.prev = toAdd;
     }
 }

--- a/src/AppendDataSets.ts
+++ b/src/AppendDataSets.ts
@@ -17,7 +17,7 @@ export function appendToDataSet(touchstones: string[],
             // ...if not add it
             // WARNING This file needs to be in same directory otherwise
             // it will break the report on the portal
-            const filename = "./impactData_" + touchstone + ".json";
+            const filename = "./impactData_" + touchstone + "_method_0.json";
             const newData: ImpactDataRow[] =
                     loadObjectFromJSONFile(filename);
 
@@ -30,4 +30,8 @@ export function appendToDataSet(touchstones: string[],
         newSeenList: seenDataSets,
     };
     return update;
+}
+
+export function getSingleDataSet(filename: string) {
+    const newData: ImpactDataRow[] = loadObjectFromJSONFile(filename);
 }

--- a/src/AppendDataSets.ts
+++ b/src/AppendDataSets.ts
@@ -7,6 +7,12 @@ export interface DataSetUpdate {
     newSeenList: string[];
 }
 
+export interface DataSet {
+    name: string,
+    data: ImpactDataRow[],
+    seen: string[]
+}
+
 export function appendToDataSet(touchstones: string[],
                                 seenDataSets: string[],
                                 curDataset: ImpactDataRow[]): DataSetUpdate {
@@ -35,4 +41,26 @@ export function appendToDataSet(touchstones: string[],
 export function getSingleDataSet(filename: string) {
     const newData: ImpactDataRow[] = loadObjectFromJSONFile(filename);
     return newData;
+}
+
+export function appendToDataSet2(toAdd: string[],
+                                 appendTo: string,
+                                 dataSets: DataSet[],
+                                 ){
+    const ds = dataSets.find(x => { return x.name == appendTo } )
+    // for each selected touchstone...
+    for (const touchstone of toAdd) {
+        // ...check if we've already added this data set...
+        if (ds.seen.indexOf(touchstone) === -1) {
+            // ...if not add it
+            // WARNING This file needs to be in same directory otherwise
+            // it will break the report on the portal
+            const filename = "./impactData_" + touchstone + "_" + appendTo + ".json";
+            const newData: ImpactDataRow[] =
+                    loadObjectFromJSONFile(filename);
+
+            ds.data = ds.data.concat(newData);
+            ds.seen.push(touchstone);
+        }
+    }
 }

--- a/src/AppendDataSets.ts
+++ b/src/AppendDataSets.ts
@@ -14,12 +14,12 @@ export interface DataSet {
 }
 
 export function getDataSet(name: string,
-                           sets: DataSet[]): ImpactDataRow[] {
+                           sets: DataSet[]): DataSet {
     const ds = sets.find(x => { return x.name == name } )
     if (ds === null) {
         console.log("WTF!")
     }
-    return ds.data
+    return ds
 }
 
 export function appendToDataSet(toAdd: string[],

--- a/src/AppendDataSets.ts
+++ b/src/AppendDataSets.ts
@@ -11,7 +11,7 @@ export interface DataSet {
     name: string;
     data: ImpactDataRow[];
     seen: string[];
-    prev: string[];
+    selectedTouchstones: string[];
 }
 
 export function getDataSet(name: string,
@@ -50,6 +50,6 @@ export function appendToDataSet(toAdd: string[],
     }
 
     if (setPrev) {
-        ds.prev = toAdd;
+        ds.selectedTouchstones = toAdd;
     }
 }

--- a/src/AppendDataSets.ts
+++ b/src/AppendDataSets.ts
@@ -8,27 +8,27 @@ export interface DataSetUpdate {
 }
 
 export interface DataSet {
-    name: string,
-    data: ImpactDataRow[],
-    seen: string[],
-    prev: string[]
+    name: string;
+    data: ImpactDataRow[];
+    seen: string[];
+    prev: string[];
 }
 
 export function getDataSet(name: string,
                            sets: DataSet[]): DataSet {
-    const ds = sets.find(x => { return x.name == name } )
+    const ds = sets.find((x) => x.name === name);
     if (ds === null) {
-        console.log("WTF!")
+        console.log("No dataset with this name");
     }
-    return ds
+    return ds;
 }
 
 export function appendToDataSet(toAdd: string[],
                                 appendTo: string,
                                 dataSets: DataSet[],
-                                setPrev: boolean = false
-                                ){
-    const ds = dataSets.find(x => { return x.name == appendTo } )
+                                setPrev: boolean = false,
+                                ) {
+    const ds = getDataSet(appendTo, dataSets);
     // for each selected touchstone...
     for (const touchstone of toAdd) {
         // ...check if we've already added this data set...

--- a/src/AppendDataSets.ts
+++ b/src/AppendDataSets.ts
@@ -17,7 +17,7 @@ export function appendToDataSet(touchstones: string[],
             // ...if not add it
             // WARNING This file needs to be in same directory otherwise
             // it will break the report on the portal
-            const filename = "./impactData_" + touchstone + "_method_0.json";
+            const filename = "./impactData_" + touchstone + "_method_2.json";
             const newData: ImpactDataRow[] =
                     loadObjectFromJSONFile(filename);
 
@@ -34,4 +34,5 @@ export function appendToDataSet(touchstones: string[],
 
 export function getSingleDataSet(filename: string) {
     const newData: ImpactDataRow[] = loadObjectFromJSONFile(filename);
+    return newData;
 }

--- a/src/DataFilterer.ts
+++ b/src/DataFilterer.ts
@@ -197,7 +197,7 @@ export class DataFilterer {
                          plotColours: { [p: string]: string }): FilteredData {
         // x axis will always be year!
         const filtData = this.filterByAll(filterOptions, impactData);
-
+console.log(filtData.length)
         // based on the metric get the top and bottom of the ratio
         // death_rate = death / population
         const meanVars = this.meanVariables(filterOptions.metric);
@@ -521,7 +521,7 @@ export class DataFilterer {
     */
     public filterByAll(filterOptions: DataFiltererOptions,
                        impactData: ImpactDataRow[]): ImpactDataRow[] {
-         // filter focal model
+        // filter focal model
         let filtData = this.filterByFocality(impactData, true);
         // filter so that support = gavi
         filtData = this.filterBySupport(filtData, filterOptions.supportType);

--- a/src/DataFilterer.ts
+++ b/src/DataFilterer.ts
@@ -197,7 +197,7 @@ export class DataFilterer {
                          plotColours: { [p: string]: string }): FilteredData {
         // x axis will always be year!
         const filtData = this.filterByAll(filterOptions, impactData);
-console.log(filtData.length)
+
         // based on the metric get the top and bottom of the ratio
         // death_rate = death / population
         const meanVars = this.meanVariables(filterOptions.metric);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -13,7 +13,7 @@ export function loadObjectFromJSONFile(path: string): any {
             return;
         },
         error(jqXHR, text, errorThrown) {
-            console.log(jqXHR + " " + text + " " + errorThrown);
+            console.log(jqXHR + " " + text + " " + errorThrown + "[" + path + "]");
         },
         type: "GET",
         url: path,

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -161,3 +161,13 @@ ul.countries-list {
 [data-toggle="collapse"]:not(.collapsed) .if-collapsed {
   display: none;
 }
+
+.btn-circle {
+  width: 20px;
+  height: 20px;
+  text-align: center;
+  padding: 0px 0;
+  font-size: 12px;
+  line-height: 1.42;
+  border-radius: 15px;
+}

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -21,14 +21,14 @@ import {WarningMessageManager} from "./WarningMessage";
 // stuff to handle the data set being split into multiple files
 const initTouchstone: string = "201710gavi-201907wue";
 const montaguDataSets: DataSet[] = [
-    { name : "method_2", data : [], seen : [], },
-    { name : "method_0", data : [], seen : [], },
-    { name : "method_1", data : [], seen : [], }
+    { name : "method_2", data : [], seen : [], prev: [] },
+    { name : "method_0", data : [], seen : [], prev: [] },
+    { name : "method_1", data : [], seen : [], prev: [] }
 ]
 
-appendToDataSet([initTouchstone], "method_2", montaguDataSets)
-appendToDataSet(["201710gavi"], "method_0", montaguDataSets)
-appendToDataSet(["201710gavi"], "method_1", montaguDataSets)
+appendToDataSet([initTouchstone], "method_2", montaguDataSets, true)
+appendToDataSet(["201710gavi"], "method_0", montaguDataSets, true)
+appendToDataSet(["201710gavi"], "method_1", montaguDataSets, true)
 
 require("./index.html");
 require("./image/logo-dark-drop.png");
@@ -380,7 +380,7 @@ class DataVisModel {
         const data: DataSet = getDataSet("method_" + method, montaguDataSets);
         this.impactData(data.data);
         this.yearMethod(method);
-        this.touchstoneFilter().selectedOptions(data.seen);
+        this.touchstoneFilter().selectedOptions(data.prev);
     }
 
     private updateXAxisOptions() {

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -23,10 +23,30 @@ const initTouchstone: string = "201710gavi-201907wue";
 export let addedDataSets: string[] = [];
 const update = appendToDataSet([initTouchstone], addedDataSets, []);
 addedDataSets = update.newSeenList;
-export let impactData = update.newDataSet;
-
+export let method_2_Data = update.newDataSet;
 export let method_0_Data = getSingleDataSet("./impactData_201710gavi_method_0.json");
 export let method_1_Data = getSingleDataSet("./impactData_201710gavi_method_1.json");
+
+export let dataSets = {
+    method_2 : {
+        data : update.newDataSet,
+        seen : update.newSeenList,
+        options : ["focality", "support", "year", "touchstone", "activityType",
+                   "country", "vaccine"]
+    },
+    method_0 : {
+        data : method_0_Data,
+        seen : ["201710gavi"],
+        options : ["focality", "support", "year", "touchstone", "activityType",
+                   "country", "vaccine"]
+    },
+    method_1 : {
+        data : method_1_Data,
+        seen : ["201710gavi"],
+        options : ["focality", "support", "year", "touchstone", "activityType",
+                   "country", "vaccine"]
+    }
+}
 
 require("./index.html");
 require("./image/logo-dark-drop.png");
@@ -64,6 +84,9 @@ class DataVisModel {
                         "coverage" ],
     };
     private currentPlot = ko.observable("Impact");
+
+    private impactData = ko.observable(method_2_Data);
+    private yearMethod = ko.observable(2);
 
     private showSidebar = ko.observable(true);
     private yearFilter = ko.observable(new RangeFilter({
@@ -270,9 +293,9 @@ class DataVisModel {
         this.touchstoneFilter().selectedOptions.subscribe(() => {
             const newUpdate: DataSetUpdate =
                 appendToDataSet(this.touchstoneFilter().selectedOptions(),
-                                addedDataSets, impactData);
+                                addedDataSets, method_2_Data);
             addedDataSets = newUpdate.newSeenList;
-            impactData = newUpdate.newDataSet;
+            method_2_Data = newUpdate.newDataSet;
             this.updateXAxisOptions();
         });
 
@@ -293,7 +316,7 @@ class DataVisModel {
             this.chartObject.destroy();
         }
 
-        const filterData = new DataFilterer().filterData(chartOptions, impactData, plotColours);
+        const filterData = new DataFilterer().filterData(chartOptions, this.impactData(), plotColours);
         const {datasets, xAxisVals} = filterData;
 
         let xAxisNames: string[] = [...xAxisVals];
@@ -317,7 +340,7 @@ class DataVisModel {
             this.chartObjectTS.destroy();
         }
 
-        const filterData = new DataFilterer().calculateMean(chartOptions, impactData, plotColours);
+        const filterData = new DataFilterer().calculateMean(chartOptions, this.impactData(), plotColours);
         const {datasets, xAxisVals} = filterData;
 
         this.filteredTSTable = new TableMaker().createWideTable(datasets, xAxisVals);
@@ -372,10 +395,31 @@ class DataVisModel {
         this.plotTitle(this.defaultTitle());
     }
 
+    private changeMethod(method: number) {
+        console.log("changeMethod")
+        switch (method) {
+            case 0:
+                this.impactData(method_0_Data);
+                this.yearMethod(0);
+                break;
+            case 1:
+                this.impactData(method_1_Data);
+                this.yearMethod(1);
+                break;
+            case 2:
+                this.impactData(method_2_Data);
+                this.yearMethod(2);
+                break;
+        }
+        console.log(this.yearMethod())
+        console.log(this.impactData()[0])
+
+    }
+
     private updateXAxisOptions() {
         // refilter the data
         const chartOptions = {...this.chartOptions(), maxPlot: -1};
-        const filteredData = new DataFilterer().filterData(chartOptions, impactData, plotColours);
+        const filteredData = new DataFilterer().filterData(chartOptions, this.impactData(), plotColours);
         this.xAxisNames(filteredData.xAxisVals);
         this.maxPlotOptions(createRangeArray(1, this.xAxisNames().length));
         this.maxBars(this.xAxisNames().length);

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -21,9 +21,9 @@ import {WarningMessageManager} from "./WarningMessage";
 // stuff to handle the data set being split into multiple files
 const initTouchstone: string = "201710gavi-201907wue";
 const montaguDataSets: DataSet[] = [
-    { name : "method_2", data : [], seen : [], prev: [] },
-    { name : "method_0", data : [], seen : [], prev: [] },
-    { name : "method_1", data : [], seen : [], prev: [] },
+    { name : "method_2", data : [], seen : [], selectedTouchstones: [] },
+    { name : "method_0", data : [], seen : [], selectedTouchstones: [] },
+    { name : "method_1", data : [], seen : [], selectedTouchstones: [] },
 ];
 
 appendToDataSet([initTouchstone], "method_2", montaguDataSets, true);
@@ -380,7 +380,7 @@ class DataVisModel {
         const data: DataSet = getDataSet(method, montaguDataSets);
         this.impactData(data.data);
         this.yearMethod(method);
-        this.touchstoneFilter().selectedOptions(data.prev);
+        this.touchstoneFilter().selectedOptions(data.selectedTouchstones);
     }
 
     private updateXAxisOptions() {

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -68,7 +68,7 @@ class DataVisModel {
     private currentPlot = ko.observable("Impact");
 
     private impactData = ko.observable(getDataSet("method_2", montaguDataSets).data);
-    private yearMethod = ko.observable(2);
+    private yearMethod = ko.observable("method_2");
 
     private showSidebar = ko.observable(true);
     private yearFilter = ko.observable(new RangeFilter({
@@ -273,7 +273,7 @@ class DataVisModel {
         });
 
         this.touchstoneFilter().selectedOptions.subscribe(() => {
-            const appendTo: string = "method_" + this.yearMethod();
+            const appendTo: string = this.yearMethod();
             appendToDataSet(this.touchstoneFilter().selectedOptions(),
                             appendTo, montaguDataSets);
 
@@ -376,8 +376,8 @@ class DataVisModel {
         this.plotTitle(this.defaultTitle());
     }
 
-    private changeMethod(method: number) {
-        const data: DataSet = getDataSet("method_" + method, montaguDataSets);
+    private changeMethod(method: string) {
+        const data: DataSet = getDataSet(method, montaguDataSets);
         this.impactData(data.data);
         this.yearMethod(method);
         this.touchstoneFilter().selectedOptions(data.prev);

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -5,7 +5,7 @@ import {saveAs} from "file-saver";
 import * as $ from "jquery";
 import * as ko from "knockout";
 import "select2/dist/css/select2.min.css";
-import {getDataSet, appendToDataSet, DataSet, DataSetUpdate} from "./AppendDataSets";
+import {appendToDataSet, DataSet, DataSetUpdate, getDataSet} from "./AppendDataSets";
 import {CustomChartOptions, impactChartConfig, timeSeriesChartConfig} from "./Chart";
 import {TableMaker, WideTableRow} from "./CreateDataTable";
 import {activityTypes, countries, dates, diseases, pineCountries, plottingVariables,
@@ -23,12 +23,12 @@ const initTouchstone: string = "201710gavi-201907wue";
 const montaguDataSets: DataSet[] = [
     { name : "method_2", data : [], seen : [], prev: [] },
     { name : "method_0", data : [], seen : [], prev: [] },
-    { name : "method_1", data : [], seen : [], prev: [] }
-]
+    { name : "method_1", data : [], seen : [], prev: [] },
+];
 
-appendToDataSet([initTouchstone], "method_2", montaguDataSets, true)
-appendToDataSet(["201710gavi"], "method_0", montaguDataSets, true)
-appendToDataSet(["201710gavi"], "method_1", montaguDataSets, true)
+appendToDataSet([initTouchstone], "method_2", montaguDataSets, true);
+appendToDataSet(["201710gavi"], "method_0", montaguDataSets, true);
+appendToDataSet(["201710gavi"], "method_1", montaguDataSets, true);
 
 require("./index.html");
 require("./image/logo-dark-drop.png");
@@ -362,8 +362,8 @@ class DataVisModel {
     }
 
     private exportAllData() {
-        const fileName : string = reportInfo.dep_id + "_data_set.zip"
-        let a = document.createElement("a");
+        const fileName : string = reportInfo.dep_id + "_data_set.zip";
+        const a = document.createElement("a");
         document.body.appendChild(a);
         a.href = "data_set.zip";
         a.download = fileName;

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -29,8 +29,6 @@ const montaguDataSets: DataSet[] = [
 appendToDataSet([initTouchstone], "method_2", montaguDataSets)
 appendToDataSet(["201710gavi"], "method_0", montaguDataSets)
 appendToDataSet(["201710gavi"], "method_1", montaguDataSets)
-console.log(montaguDataSets)
-
 
 require("./index.html");
 require("./image/logo-dark-drop.png");
@@ -299,7 +297,6 @@ class DataVisModel {
         if (this.chartObject) {
             this.chartObject.destroy();
         }
-console.log(this.impactData().length)
         const filterData = new DataFilterer().filterData(chartOptions, this.impactData(), plotColours);
         const {datasets, xAxisVals} = filterData;
 

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -5,7 +5,7 @@ import {saveAs} from "file-saver";
 import * as $ from "jquery";
 import * as ko from "knockout";
 import "select2/dist/css/select2.min.css";
-import {appendToDataSet, DataSetUpdate} from "./AppendDataSets";
+import {appendToDataSet, getSingleDataSet, DataSetUpdate} from "./AppendDataSets";
 import {CustomChartOptions, impactChartConfig, timeSeriesChartConfig} from "./Chart";
 import {TableMaker, WideTableRow} from "./CreateDataTable";
 import {activityTypes, countries, dates, diseases, pineCountries, plottingVariables,
@@ -24,6 +24,9 @@ export let addedDataSets: string[] = [];
 const update = appendToDataSet([initTouchstone], addedDataSets, []);
 addedDataSets = update.newSeenList;
 export let impactData = update.newDataSet;
+
+export let method_0_Data = getSingleDataSet("./impactData_201710gavi_method_0.json");
+export let method_1_Data = getSingleDataSet("./impactData_201710gavi_method_1.json");
 
 require("./index.html");
 require("./image/logo-dark-drop.png");

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -5,7 +5,7 @@ import {saveAs} from "file-saver";
 import * as $ from "jquery";
 import * as ko from "knockout";
 import "select2/dist/css/select2.min.css";
-import {appendToDataSet, getSingleDataSet, DataSetUpdate} from "./AppendDataSets";
+import {appendToDataSet, appendToDataSet2, getSingleDataSet, DataSet, DataSetUpdate} from "./AppendDataSets";
 import {CustomChartOptions, impactChartConfig, timeSeriesChartConfig} from "./Chart";
 import {TableMaker, WideTableRow} from "./CreateDataTable";
 import {activityTypes, countries, dates, diseases, pineCountries, plottingVariables,
@@ -27,26 +27,50 @@ export let method_2_Data = update.newDataSet;
 export let method_0_Data = getSingleDataSet("./impactData_201710gavi_method_0.json");
 export let method_1_Data = getSingleDataSet("./impactData_201710gavi_method_1.json");
 
-export let dataSets = {
-    method_2 : {
-        data : update.newDataSet,
-        seen : update.newSeenList,
-        options : ["focality", "support", "year", "touchstone", "activityType",
-                   "country", "vaccine"]
+
+// const montaguDataSets: DataSet[] = [
+//     {
+//         name : "method_2",
+//         data : update.newDataSet,
+//         seen : update.newSeenList,
+//     },
+//     {
+//         name : "method_0",
+//         data : method_0_Data,
+//         seen : ["201710gavi"],
+//     },
+//     {
+//         name : "method_1",
+//         data : method_1_Data,
+//         seen : ["201710gavi"],
+//     }
+// ]
+
+const montaguDataSets: DataSet[] = [
+    {
+        name : "method_2",
+        data : [],
+        seen : [],
     },
-    method_0 : {
-        data : method_0_Data,
-        seen : ["201710gavi"],
-        options : ["focality", "support", "year", "touchstone", "activityType",
-                   "country", "vaccine"]
+    {
+        name : "method_0",
+        data : [],
+        seen : [],
     },
-    method_1 : {
-        data : method_1_Data,
-        seen : ["201710gavi"],
-        options : ["focality", "support", "year", "touchstone", "activityType",
-                   "country", "vaccine"]
+    {
+        name : "method_1",
+        data : [],
+        seen : [],
     }
-}
+]
+
+appendToDataSet2([initTouchstone], "method_2", montaguDataSets)
+console.log(montaguDataSets)
+appendToDataSet2(["201710gavi"], "method_0", montaguDataSets)
+console.log(montaguDataSets)
+appendToDataSet2(["201710gavi"], "method_1", montaguDataSets)
+console.log(montaguDataSets)
+
 
 require("./index.html");
 require("./image/logo-dark-drop.png");

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -5,7 +5,7 @@ import {saveAs} from "file-saver";
 import * as $ from "jquery";
 import * as ko from "knockout";
 import "select2/dist/css/select2.min.css";
-import {appendToDataSet, appendToDataSet2, getSingleDataSet, DataSet, DataSetUpdate} from "./AppendDataSets";
+import {getDataSet, appendToDataSet, DataSet, DataSetUpdate} from "./AppendDataSets";
 import {CustomChartOptions, impactChartConfig, timeSeriesChartConfig} from "./Chart";
 import {TableMaker, WideTableRow} from "./CreateDataTable";
 import {activityTypes, countries, dates, diseases, pineCountries, plottingVariables,
@@ -20,55 +20,15 @@ import {WarningMessageManager} from "./WarningMessage";
 
 // stuff to handle the data set being split into multiple files
 const initTouchstone: string = "201710gavi-201907wue";
-export let addedDataSets: string[] = [];
-const update = appendToDataSet([initTouchstone], addedDataSets, []);
-addedDataSets = update.newSeenList;
-export let method_2_Data = update.newDataSet;
-export let method_0_Data = getSingleDataSet("./impactData_201710gavi_method_0.json");
-export let method_1_Data = getSingleDataSet("./impactData_201710gavi_method_1.json");
-
-
-// const montaguDataSets: DataSet[] = [
-//     {
-//         name : "method_2",
-//         data : update.newDataSet,
-//         seen : update.newSeenList,
-//     },
-//     {
-//         name : "method_0",
-//         data : method_0_Data,
-//         seen : ["201710gavi"],
-//     },
-//     {
-//         name : "method_1",
-//         data : method_1_Data,
-//         seen : ["201710gavi"],
-//     }
-// ]
-
 const montaguDataSets: DataSet[] = [
-    {
-        name : "method_2",
-        data : [],
-        seen : [],
-    },
-    {
-        name : "method_0",
-        data : [],
-        seen : [],
-    },
-    {
-        name : "method_1",
-        data : [],
-        seen : [],
-    }
+    { name : "method_2", data : [], seen : [], },
+    { name : "method_0", data : [], seen : [], },
+    { name : "method_1", data : [], seen : [], }
 ]
 
-appendToDataSet2([initTouchstone], "method_2", montaguDataSets)
-console.log(montaguDataSets)
-appendToDataSet2(["201710gavi"], "method_0", montaguDataSets)
-console.log(montaguDataSets)
-appendToDataSet2(["201710gavi"], "method_1", montaguDataSets)
+appendToDataSet([initTouchstone], "method_2", montaguDataSets)
+appendToDataSet(["201710gavi"], "method_0", montaguDataSets)
+appendToDataSet(["201710gavi"], "method_1", montaguDataSets)
 console.log(montaguDataSets)
 
 
@@ -109,7 +69,7 @@ class DataVisModel {
     };
     private currentPlot = ko.observable("Impact");
 
-    private impactData = ko.observable(method_2_Data);
+    private impactData = ko.observable(getDataSet("method_2", montaguDataSets));
     private yearMethod = ko.observable(2);
 
     private showSidebar = ko.observable(true);
@@ -315,11 +275,10 @@ class DataVisModel {
         });
 
         this.touchstoneFilter().selectedOptions.subscribe(() => {
-            const newUpdate: DataSetUpdate =
-                appendToDataSet(this.touchstoneFilter().selectedOptions(),
-                                addedDataSets, method_2_Data);
-            addedDataSets = newUpdate.newSeenList;
-            method_2_Data = newUpdate.newDataSet;
+            const appendTo: string = "method_" + this.yearMethod();
+            appendToDataSet(this.touchstoneFilter().selectedOptions(),
+                            appendTo, montaguDataSets);
+
             this.updateXAxisOptions();
         });
 
@@ -339,7 +298,7 @@ class DataVisModel {
         if (this.chartObject) {
             this.chartObject.destroy();
         }
-
+console.log(this.impactData().length)
         const filterData = new DataFilterer().filterData(chartOptions, this.impactData(), plotColours);
         const {datasets, xAxisVals} = filterData;
 
@@ -420,24 +379,8 @@ class DataVisModel {
     }
 
     private changeMethod(method: number) {
-        console.log("changeMethod")
-        switch (method) {
-            case 0:
-                this.impactData(method_0_Data);
-                this.yearMethod(0);
-                break;
-            case 1:
-                this.impactData(method_1_Data);
-                this.yearMethod(1);
-                break;
-            case 2:
-                this.impactData(method_2_Data);
-                this.yearMethod(2);
-                break;
-        }
-        console.log(this.yearMethod())
-        console.log(this.impactData()[0])
-
+        this.impactData(getDataSet("method_" + method, montaguDataSets));
+        this.yearMethod(method);
     }
 
     private updateXAxisOptions() {

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -69,7 +69,7 @@ class DataVisModel {
     };
     private currentPlot = ko.observable("Impact");
 
-    private impactData = ko.observable(getDataSet("method_2", montaguDataSets));
+    private impactData = ko.observable(getDataSet("method_2", montaguDataSets).data);
     private yearMethod = ko.observable(2);
 
     private showSidebar = ko.observable(true);
@@ -279,6 +279,7 @@ class DataVisModel {
             appendToDataSet(this.touchstoneFilter().selectedOptions(),
                             appendTo, montaguDataSets);
 
+            this.impactData(getDataSet(appendTo, montaguDataSets).data);
             this.updateXAxisOptions();
         });
 
@@ -379,8 +380,10 @@ console.log(this.impactData().length)
     }
 
     private changeMethod(method: number) {
-        this.impactData(getDataSet("method_" + method, montaguDataSets));
+        const data: DataSet = getDataSet("method_" + method, montaguDataSets);
+        this.impactData(data.data);
         this.yearMethod(method);
+        this.touchstoneFilter().selectedOptions(data.seen);
     }
 
     private updateXAxisOptions() {

--- a/src/index.html
+++ b/src/index.html
@@ -274,7 +274,7 @@
                                 </div>
                             </div>
                             <div class="col-3">
-                                <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#methodModal">
+                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#methodModal">
                                     <i class="fa fa-question-circle"></i>
                                     Help
                                 </button>

--- a/src/index.html
+++ b/src/index.html
@@ -258,31 +258,30 @@
         <div id="impact" class="container tab-pane" data-bind="css: {'active': currentPlot() == 'Impact'}">
             <div class="row">
                 <div class="col-12 p-5">
-
-<form class="mb-0">
-    <div class="form-group row">
-        <div class="col-9">
-            <div class="btn-group mt-1 mb-5" role="group">
-                    <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(0),
-                     css: {active: yearMethod() == 0}">Cross-sectional
-                    </button>
-                    <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(1),
-                     css: {active: yearMethod() == 1}">Lifetime
-                    </button>
-                    <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod(2),
-                     css: {active: yearMethod() == 2}">Year of vaccination
-                    </button>
-            </div>
-        </div>
-        <div class="col-3">
-            <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#methodModal">
-                <i class="fa fa-question-circle"></i>
-                Help
-            </button>
-        </div>
-    </div>
-</form>
-<hr/>
+                    <form class="mb-0">
+                        <div class="form-group row">
+                            <div class="col-9">
+                                <div class="btn-group mt-1 mb-5" role="group">
+                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(0),
+                                         css: {active: yearMethod() == 0}">Cross-sectional
+                                        </button>
+                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(1),
+                                         css: {active: yearMethod() == 1}">Lifetime
+                                        </button>
+                                        <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod(2),
+                                         css: {active: yearMethod() == 2}">Year of vaccination
+                                        </button>
+                                </div>
+                            </div>
+                            <div class="col-3">
+                                <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#methodModal">
+                                    <i class="fa fa-question-circle"></i>
+                                    Help
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                    <hr/>
                     <form class="mb-5">
                         <div class="form-group row">
                             <div class="col-4">
@@ -317,8 +316,6 @@
                             </div>
                         </div>
                     </form>
-                    <hr/>
-
 
                     <div class="btn-group mt-1 mb-5" role="group">
                         <button type="button" class="btn btn-primary active" data-bind="click: () => changeBurden('deaths'),
@@ -334,7 +331,6 @@
                          css: {active: humanReadableBurdenOutcome() == 'fvps'}">FVPS
                         </button>
                     </div>
-                    <hr/>
 
                     <p style="font-weight:bold;color:red"
                         data-bind="text: warningMessage, visible: showWarning">
@@ -377,6 +373,30 @@
         <div id="timeseries" class="container tab-pane" data-bind="css: {'active': currentPlot() == 'Time series'}">
             <div class="row">
                 <div class="col-12 p-5">
+                    <form class="mb-0">
+                        <div class="form-group row">
+                            <div class="col-9">
+                                <div class="btn-group mt-1 mb-5" role="group">
+                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(0),
+                                         css: {active: yearMethod() == 0}">Cross-sectional
+                                        </button>
+                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(1),
+                                         css: {active: yearMethod() == 1}">Lifetime
+                                        </button>
+                                        <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod(2),
+                                         css: {active: yearMethod() == 2}">Year of vaccination
+                                        </button>
+                                </div>
+                            </div>
+                            <div class="col-3">
+                                <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#methodModal">
+                                    <i class="fa fa-question-circle"></i>
+                                    Help
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                    <hr/>
                     <form class="mb-5">
                         <div class="form-group row">
                             <div class="col-4">
@@ -397,19 +417,6 @@
                             </div>
                         </div>
                     </form>
-
-                    <div class="btn-group mt-1 mb-5" role="group">
-                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(0),
-                         css: {active: yearMethod() == 0}">Method 0
-                        </button>
-                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(1),
-                         css: {active: yearMethod() == 1}">Method 1
-                        </button>
-                        <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod(2),
-                         css: {active: yearMethod() == 2}">Method 2
-                        </button>
-                    </div>
-
                     <div class="btn-group mt-1 mb-6" role="group">
                         <button type="button" class="btn btn-primary active" data-bind="click: () => changeBurden('deaths'),
                          css: {active: humanReadableBurdenOutcome() == 'deaths'}">Deaths

--- a/src/index.html
+++ b/src/index.html
@@ -261,7 +261,7 @@
                     <form class="mb-0">
                         <div class="form-group row">
                             <div class="col-9">
-                                <div class="btn-group mt-1 mb-5" role="group">
+                                <div class="btn-group mt-1" role="group">
                                         <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod('method_0'),
                                          css: {active: yearMethod() == 'method_0'}">Cross-sectional
                                         </button>
@@ -273,13 +273,10 @@
                                         </button>
                                 </div>
                             </div>
-                            <div class="col-3">
-                                <button type="button" class="btn btn-info" data-toggle="modal" data-target="#methodModal">
-                                    <i class="fa fa-question-circle"></i>
-                                    Help
-                                </button>
-                            </div>
                         </div>
+                        <button type="button" class="btn btn-info btn-circle" data-toggle="modal" data-target="#methodModal">
+                            <i class="fa fa-question-circle"></i>
+                        </button>
                     </form>
                     <hr/>
                     <form class="mb-5">

--- a/src/index.html
+++ b/src/index.html
@@ -292,6 +292,18 @@
                     </form>
 
                     <div class="btn-group mt-1 mb-5" role="group">
+                            <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(0),
+                             css: {active: yearMethod() == 0}">Method 0
+                            </button>
+                            <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(1),
+                             css: {active: yearMethod() == 1}">Method 1
+                            </button>
+                            <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod(2),
+                             css: {active: yearMethod() == 2}">Method 2
+                            </button>
+                    </div>
+
+                    <div class="btn-group mt-1 mb-5" role="group">
                         <button type="button" class="btn btn-primary active" data-bind="click: () => changeBurden('deaths'),
                          css: {active: humanReadableBurdenOutcome() == 'deaths'}">Deaths
                         </button>
@@ -367,6 +379,18 @@
                             </div>
                         </div>
                     </form>
+
+                    <div class="btn-group mt-1 mb-5" role="group">
+                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(0),
+                         css: {active: yearMethod() == 0}">Method 0
+                        </button>
+                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(1),
+                         css: {active: yearMethod() == 1}">Method 1
+                        </button>
+                        <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod(2),
+                         css: {active: yearMethod() == 2}">Method 2
+                        </button>
+                    </div>
 
                     <div class="btn-group mt-1 mb-6" role="group">
                         <button type="button" class="btn btn-primary active" data-bind="click: () => changeBurden('deaths'),

--- a/src/index.html
+++ b/src/index.html
@@ -262,14 +262,14 @@
                         <div class="form-group row">
                             <div class="col-9">
                                 <div class="btn-group mt-1 mb-5" role="group">
-                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(0),
-                                         css: {active: yearMethod() == 0}">Cross-sectional
+                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod('method_0'),
+                                         css: {active: yearMethod() == 'method_0'}">Cross-sectional
                                         </button>
-                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(1),
-                                         css: {active: yearMethod() == 1}">Lifetime
+                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod('method_1'),
+                                         css: {active: yearMethod() == 'method_1'}">Lifetime
                                         </button>
-                                        <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod(2),
-                                         css: {active: yearMethod() == 2}">Year of vaccination
+                                        <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod('method_2'),
+                                         css: {active: yearMethod() == 'method_2'}">Year of vaccination
                                         </button>
                                 </div>
                             </div>
@@ -328,7 +328,7 @@
                          css: {active: humanReadableBurdenOutcome() == 'cases'}">Cases
                         </button>
                         <button type="button" class="btn btn-primary" data-bind="click: () => changeBurden('fvps'),
-                         css: {active: humanReadableBurdenOutcome() == 'fvps'}">FVPS
+                         css: {active: humanReadableBurdenOutcome() == 'fvps'}, enable: yearMethod() == 'method_2'">FVPS
                         </button>
                     </div>
 
@@ -377,14 +377,14 @@
                         <div class="form-group row">
                             <div class="col-9">
                                 <div class="btn-group mt-1 mb-5" role="group">
-                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(0),
-                                         css: {active: yearMethod() == 0}">Cross-sectional
+                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod('method_0'),
+                                         css: {active: yearMethod() == 'method_0'}">Cross-sectional
                                         </button>
-                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(1),
-                                         css: {active: yearMethod() == 1}">Lifetime
+                                        <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod('method_1'),
+                                         css: {active: yearMethod() == 'method_1'}">Lifetime
                                         </button>
-                                        <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod(2),
-                                         css: {active: yearMethod() == 2}">Year of vaccination
+                                        <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod('method_2'),
+                                         css: {active: yearMethod() == 'method_2'}">Year of vaccination
                                         </button>
                                 </div>
                             </div>
@@ -428,16 +428,16 @@
                          css: {active: humanReadableBurdenOutcome() == 'cases'}">Cases
                         </button>
                         <button type="button" class="btn btn-primary" data-bind="click: () => changeBurden('fvps'),
-                         css: {active: humanReadableBurdenOutcome() == 'fvps'}">FVPS
+                         css: {active: humanReadableBurdenOutcome() == 'fvps'}, enable: yearMethod() == 'method_2'">FVPS
                         </button>
                         <button class="btn btn-warning" type="button" class="btn btn-primary" data-bind="click: () => changeBurden('coverage'),
-                         css: {active: humanReadableBurdenOutcome() == 'coverage'}">Coverage
+                         css: {active: humanReadableBurdenOutcome() == 'coverage'}, enable: yearMethod() == 'method_2'">Coverage
                         </button>
                         <button class="btn btn-warning" type="button" class="btn btn-primary" data-bind="click: () => changeBurden('deathsRate'),
-                         css: {active: humanReadableBurdenOutcome() == 'deathsRate'}">Deaths (rate)
+                         css: {active: humanReadableBurdenOutcome() == 'deathsRate'}, enable: yearMethod() == 'method_2'">Deaths (rate)
                         </button>
                         <button class="btn btn-warning" type="button" class="btn btn-primary" data-bind="click: () => changeBurden('casesRate'),
-                         css: {active: humanReadableBurdenOutcome() == 'casesRate'}">Cases (rate)
+                         css: {active: humanReadableBurdenOutcome() == 'casesRate'}, enable: yearMethod() == 'method_2'">Cases (rate)
                         </button>
                     </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -492,7 +492,7 @@
                 <p>This method can be thought of as the impact by calendar year, <i>e.g.</i> the number of cases prevented in a given year. While the resulting estimates are intuitively easy to understand, they fail to represent the long-term future impact of vaccination on individual disease risk. In addition, the impact estimates cannot be linked to specific vaccination activities.</p>
 
                 <h2>Lifetime</h2>
-                <p>This method can be thought of as the impact by birth year, <i>e.g.</i> the number of cases prevented in a cohort born in a given year over the course of their lifetime. Note that we calculate impact for birth cohorts from 2000 to 2030, and consider the lifetime upto 2100. A lifetime or cohort approach to presenting impact is appropriate for capturing the direct effects of vaccination in protecting the immunised individual. However, indirect effects of vaccination (acting via herd immunity) play out across the whole population.</p>
+                <p>This method can be thought of as the impact by birth year, <i>e.g.</i> the number of cases prevented in a cohort born in a given year over the course of their lifetime. Note that we calculate impact for birth cohorts from 2000 to 2030, and consider the lifetime up to 2100. A lifetime or cohort approach to presenting impact is appropriate for capturing the direct effects of vaccination in protecting the immunised individual. However, indirect effects of vaccination (acting via herd immunity) play out across the whole population.</p>
 
                 <h2>Year of Vaccination</h2>
                 <p>This is the approach used by VIMC to estimate vaccine impact by year of vaccination. It can be used to easily determine the efficacy of a particular vaccination campaign.</p>
@@ -501,7 +501,7 @@
                 <a href="https://www.vaccineimpact.org/resources/" target="_blank">Vaccine Impact Modelling Consortium</a> website. In particular a in pre-print of the
                 <a href="https://medrxiv.org/cgi/content/short/19004358v1" target="_blank">first VIMC paper</a> and the associated
 
-                 <a href="https://www.vaccineimpact.org/resources/VIMC_impact_estimates-03Sep19.html" target="_blank">guidance notes.</a> </p>
+                 <a href="https://www.vaccineimpact.org/resources/VIMC_impact_estimates-03Sep19.html" target="_blank">technical description of the methods.</a> </p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>

--- a/src/index.html
+++ b/src/index.html
@@ -495,10 +495,10 @@
                 <p>This method can be thought of as the impact by birth year, <i>e.g.</i> the number of cases prevented in a cohort born in a given year over the course of their lifetime. Note that we calculate impact for birth cohorts from 2000 to 2030, and consider the lifetime upto 2100. A lifetime or cohort approach to presenting impact is appropriate for capturing the direct effects of vaccination in protecting the immunised individual. However, indirect effects of vaccination (acting via herd immunity) play out across the whole population.</p>
 
                 <h2>Year of Vaccination</h2>
-                <p>This is the approach used by VIMC to estimate vaccine impact by year of vaccination. It can be used to accurately determine the efficacy of a particular vaccination campaign.</p>
+                <p>This is the approach used by VIMC to estimate vaccine impact by year of vaccination. It can be used to easily determine the efficacy of a particular vaccination campaign.</p>
 
-                <p>More in-depth descriptions of the science underlying methods can be found at the
-                <a href="https://www.vaccineimpact.org/resources/" target="_blank">Vaccine Impact Modelling Consortium</a> website. In particular a pre-print of the
+                <p>More in-depth descriptions of the science underlying the methods can be found at the
+                <a href="https://www.vaccineimpact.org/resources/" target="_blank">Vaccine Impact Modelling Consortium</a> website. In particular a in pre-print of the
                 <a href="https://medrxiv.org/cgi/content/short/19004358v1" target="_blank">first VIMC paper</a> and the associated
 
                  <a href="https://www.vaccineimpact.org/resources/VIMC_impact_estimates-03Sep19.html" target="_blank">guidance notes.</a> </p>

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,8 @@
     <!-- We seem to need this to get the collapsable card to work -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"></script>
 
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+
     <!-- Loading Screen -->
     <script type="text/javascript">
         $(window).load(function() {
@@ -256,6 +258,31 @@
         <div id="impact" class="container tab-pane" data-bind="css: {'active': currentPlot() == 'Impact'}">
             <div class="row">
                 <div class="col-12 p-5">
+
+<form class="mb-0">
+    <div class="form-group row">
+        <div class="col-9">
+            <div class="btn-group mt-1 mb-5" role="group">
+                    <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(0),
+                     css: {active: yearMethod() == 0}">Cross-sectional
+                    </button>
+                    <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(1),
+                     css: {active: yearMethod() == 1}">Lifetime
+                    </button>
+                    <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod(2),
+                     css: {active: yearMethod() == 2}">Year of vaccination
+                    </button>
+            </div>
+        </div>
+        <div class="col-3">
+            <button type="button" class="btn btn-warning" data-toggle="modal" data-target="#methodModal">
+                <i class="fa fa-question-circle"></i>
+                Help
+            </button>
+        </div>
+    </div>
+</form>
+<hr/>
                     <form class="mb-5">
                         <div class="form-group row">
                             <div class="col-4">
@@ -290,18 +317,8 @@
                             </div>
                         </div>
                     </form>
+                    <hr/>
 
-                    <div class="btn-group mt-1 mb-5" role="group">
-                            <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(0),
-                             css: {active: yearMethod() == 0}">Method 0
-                            </button>
-                            <button type="button" class="btn btn-primary" data-bind="click: () => changeMethod(1),
-                             css: {active: yearMethod() == 1}">Method 1
-                            </button>
-                            <button type="button" class="btn btn-primary active" data-bind="click: () => changeMethod(2),
-                             css: {active: yearMethod() == 2}">Method 2
-                            </button>
-                    </div>
 
                     <div class="btn-group mt-1 mb-5" role="group">
                         <button type="button" class="btn btn-primary active" data-bind="click: () => changeBurden('deaths'),
@@ -317,6 +334,7 @@
                          css: {active: humanReadableBurdenOutcome() == 'fvps'}">FVPS
                         </button>
                     </div>
+                    <hr/>
 
                     <p style="font-weight:bold;color:red"
                         data-bind="text: warningMessage, visible: showWarning">
@@ -450,6 +468,39 @@
     </div>
 </div>
 
+</div>
+
+<!-- Modal -->
+<div class="modal fade" id="methodModal" tabindex="-1" role="dialog" aria-labelledby="methodModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="methodModalLabel">Explanation of methods</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <h2>Cross-sectional</h2>
+                <p>This method can be thought of as the impact by calendar year, <i>e.g.</i> the number of cases prevented in a given year. While the resulting estimates are intuitively easy to understand, they fail to represent the long-term future impact of vaccination on individual disease risk. In addition, the impact estimates cannot be linked to specific vaccination activities.</p>
+
+                <h2>Lifetime</h2>
+                <p>This method can be thought of as the impact by birth year, <i>e.g.</i> the number of cases prevented in a cohort born in a given year over the course of their lifetime. Note that we calculate impact for birth cohorts from 2000 to 2030, and consider the lifetime upto 2100. A lifetime or cohort approach to presenting impact is appropriate for capturing the direct effects of vaccination in protecting the immunised individual. However, indirect effects of vaccination (acting via herd immunity) play out across the whole population.</p>
+
+                <h2>Year of Vaccination</h2>
+                <p>This is the approach used by VIMC to estimate vaccine impact by year of vaccination. It can be used to accurately determine the efficacy of a particular vaccination campaign.</p>
+
+                <p>More in-depth descriptions of the science underlying methods can be found at the
+                <a href="https://www.vaccineimpact.org/resources/" target="_blank">Vaccine Impact Modelling Consortium</a> website. In particular a pre-print of the
+                <a href="https://medrxiv.org/cgi/content/short/19004358v1" target="_blank">first VIMC paper</a> and the associated
+
+                 <a href="https://www.vaccineimpact.org/resources/VIMC_impact_estimates-03Sep19.html" target="_blank">guidance notes.</a> </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script src="bundle.js"></script>

--- a/tests/AppendDataSetsTests.ts
+++ b/tests/AppendDataSetsTests.ts
@@ -1,0 +1,61 @@
+import * as ut from "../src/Utils"
+import * as sinon from "sinon";
+import {appendToDataSet, DataSet, getDataSet} from "../src/AppendDataSets";
+import {expect} from "chai";
+
+
+
+describe("appendToDataSet", () => {
+
+    it("Test appendToDataSet", () => {
+      // mock here
+      const stub = sinon.stub(ut, 'loadObjectFromJSONFile');
+      stub.returns(
+        [
+          {"country":"FJI","country_name":"Fiji"},
+          {"country":"GMB","country_name":"Gambia"},
+          {"country":"GEO","country_name":"Georgia"},
+          {"country":"GHA","country_name":"Ghana"},
+          {"country":"GTM","country_name":"Guatemala"},
+        ]
+      );
+
+      const ds: DataSet[] = [
+        { name : "data_A", data : [], seen : [], prev: [] },
+        { name : "data_B", data : [], seen : [], prev: [] },
+        { name : "data_C", data : [], seen : [], prev: [] },
+      ]
+
+      appendToDataSet(["XXX"], "data_A", ds, false);
+      expect(getDataSet("data_A", ds).data).to.have.length(5);
+
+      appendToDataSet(["YYY"], "data_A", ds, false);
+      expect(getDataSet("data_A", ds).data).to.have.length(10);
+
+      appendToDataSet(["YYY"], "data_A", ds, false);
+      expect(getDataSet("data_A", ds).data).to.have.length(10);
+      expect(getDataSet("data_A", ds).seen).to.have.members(["XXX", "YYY"]);
+      expect(getDataSet("data_A", ds).prev).to.have.members([]);
+
+      appendToDataSet(["YYY"], "data_B", ds, true);
+      expect(getDataSet("data_B", ds).data).to.have.length(5);
+      expect(getDataSet("data_B", ds).seen).to.have.members(["YYY"]);
+      expect(getDataSet("data_B", ds).prev).to.have.members(["YYY"]);
+
+
+      expect(getDataSet("data_C", ds).data).to.have.length(0);
+      expect(getDataSet("data_C", ds).seen).to.have.length(0);
+      expect(getDataSet("data_C", ds).prev).to.have.length(0);
+
+
+      // make sure we capture the console message
+      let spy = sinon.spy(console, 'log');
+      appendToDataSet(["ZZZ"], "data_D", ds, true);
+      sinon.assert.calledWith(spy, "No dataset named data_D");
+      expect(ds).to.have.length(3);
+      
+      spy.restore();
+      stub.restore();
+    })
+});
+

--- a/tests/AppendDataSetsTests.ts
+++ b/tests/AppendDataSetsTests.ts
@@ -21,9 +21,9 @@ describe("appendToDataSet", () => {
       );
 
       const ds: DataSet[] = [
-        { name : "data_A", data : [], seen : [], prev: [] },
-        { name : "data_B", data : [], seen : [], prev: [] },
-        { name : "data_C", data : [], seen : [], prev: [] },
+        { name : "data_A", data : [], seen : [], selectedTouchstones: [] },
+        { name : "data_B", data : [], seen : [], selectedTouchstones: [] },
+        { name : "data_C", data : [], seen : [], selectedTouchstones: [] },
       ]
 
       appendToDataSet(["XXX"], "data_A", ds, false);
@@ -35,17 +35,17 @@ describe("appendToDataSet", () => {
       appendToDataSet(["YYY"], "data_A", ds, false);
       expect(getDataSet("data_A", ds).data).to.have.length(10);
       expect(getDataSet("data_A", ds).seen).to.have.members(["XXX", "YYY"]);
-      expect(getDataSet("data_A", ds).prev).to.have.members([]);
+      expect(getDataSet("data_A", ds).selectedTouchstones).to.have.members([]);
 
       appendToDataSet(["YYY"], "data_B", ds, true);
       expect(getDataSet("data_B", ds).data).to.have.length(5);
       expect(getDataSet("data_B", ds).seen).to.have.members(["YYY"]);
-      expect(getDataSet("data_B", ds).prev).to.have.members(["YYY"]);
+      expect(getDataSet("data_B", ds).selectedTouchstones).to.have.members(["YYY"]);
 
 
       expect(getDataSet("data_C", ds).data).to.have.length(0);
       expect(getDataSet("data_C", ds).seen).to.have.length(0);
-      expect(getDataSet("data_C", ds).prev).to.have.length(0);
+      expect(getDataSet("data_C", ds).selectedTouchstones).to.have.length(0);
 
 
       // make sure we capture the console message


### PR DESCRIPTION
This PR updates the data vis tool to use the data in the paper (as well as retain the old data since this is going to be used in the second paper).

Previously we only had one dataset (`impactData`) this has been replaced with an array of datasets  `montaguDataSets` that we jump between. 

As before the dataset source files are split into multiple files to cut down on loading times, so we need to keep track of which file have been read into the app, this is done with the `seen` field in the function `appendToDataSet`.

We've also added UI buttons to jump between the data sets and a modal help to explain the difference - this is mostly a c+p job, until we get feedback from the science team. 

The `prev` field is a bit of hack - different methods need not have the same touchstones loading, so  when move from one methods to another we have update the selected touchstones or else we can end up in the situation where we display empty datasets.

The generate fake data script has been rewritten to support the new approach. So you will need to re-run the script to test [it is probably best to start with a clean clone of the repo]