### PR TITLE
Make Metrics and Options more versitile

### DIFF
--- a/src/DataFilterer.ts
+++ b/src/DataFilterer.ts
@@ -134,9 +134,9 @@ export class DataFilterer {
                     impactData: ImpactDataRow[],
                     metsAndOpts: MetricsAndOptions,
                     plotColours: { [p: string]: string }): FilteredData {
-    const averaged_metrics = ["coverage", "deaths_averted_rate",
-                              "cases_averted_rate", "dalys_averted_rate"];
-    const averaged = averaged_metrics.includes(filterOptions.metric);
+    const averagedMetrics = ["coverage", "deaths_averted_rate",
+                             "cases_averted_rate", "dalys_averted_rate"];
+    const averaged = averagedMetrics.includes(filterOptions.metric);
     if (averaged) {
       return this.calculateMean(filterOptions, impactData, metsAndOpts, plotColours);
     } else {
@@ -502,6 +502,9 @@ export class DataFilterer {
   public filterByAll(filterOptions: DataFiltererOptions,
                      metsAndOpts: MetricsAndOptions,
                      impactData: ImpactDataRow[]): ImpactDataRow[] {
+    // we can filter by dualOptions and filterOptions
+    const usedFilters
+                    = metsAndOpts.dualOptions.concat(metsAndOpts.filterOptions);
     let filtData = impactData;
     // filter by secret options
     if (metsAndOpts.secretOptions) {
@@ -511,42 +514,42 @@ export class DataFilterer {
       }
     }
     // filter so that support = gavi
-    if (metsAndOpts.filterOptions.indexOf("support_type") > -1) {
+    if (usedFilters.indexOf("support_type") > -1) {
       filtData = this.filterIsInList(filtData, "support_type",
                        filterOptions.supportType);
     }
     // filter by years
-    if (metsAndOpts.filterOptions.indexOf("year") > -1) {
+    if (usedFilters.indexOf("year") > -1) {
       filtData = this.filterByNumericBetween(filtData, "year",
                  filterOptions.yearLow, filterOptions.yearHigh);
     }
     // filter by touchstone
-    if (metsAndOpts.filterOptions.indexOf("touchstone") > -1) {
+    if (usedFilters.indexOf("touchstone") > -1) {
       filtData = this.filterIsInList(filtData, "touchstone",
                        filterOptions.selectedTouchstones);
     }
     // filter by activity type
-    if (metsAndOpts.filterOptions.indexOf("activity_type") > -1) {
+    if (usedFilters.indexOf("activity_type") > -1) {
       filtData = this.filterIsInList(filtData, "activity_type",
                        filterOptions.activityTypes);
     }
     // filter by country
-    if (metsAndOpts.filterOptions.indexOf("country") > -1) {
+    if (usedFilters.indexOf("country") > -1) {
       filtData = this.filterIsInList(filtData, "country",
                        filterOptions.selectedCountries);
     }
     // filter by vaccine
-    if (metsAndOpts.filterOptions.indexOf("vaccine") > -1) {
+    if (usedFilters.indexOf("vaccine") > -1) {
       filtData = this.filterIsInList(filtData, "vaccine",
                        filterOptions.selectedVaccines);
     }
     // filter by age group
-    if (metsAndOpts.filterOptions.indexOf("age_group") > -1) {
+    if (usedFilters.indexOf("age_group") > -1) {
       filtData = this.filterByIsEqualTo(filtData, "age_group",
                         filterOptions.ageGroup);
     }
     // filter by disease
-    if (metsAndOpts.filterOptions.indexOf("disease") > -1) {
+    if (usedFilters.indexOf("disease") > -1) {
       filtData = this.filterIsInList(filtData, "disease",
                        filterOptions.selectedDiseases);
     }

--- a/src/MetricsAndOptions.ts
+++ b/src/MetricsAndOptions.ts
@@ -3,17 +3,25 @@ export interface MetricsAndOptions {
   mode: "public" | "private";
   // These are the metric columns in the data set e.g. deaths, dalys, cases_averted etc.
   metrics: string[];
-  // These are the methods we can toggle between
+  // These are the methods we can toggle between e.g. deaths, daly, FVPs, etc.
   methods: string[];
   // These are the columns that we filter the data by and can stratify by
   // e.g. country, year, vaccine
-  filterOptions: string[];
+  dualOptions: string[];
   // These are columns that we stratify by but not filter by e.g. continent
   // (we never filter by continent, we filter by country)
-  otherOptions?: string[];
+  stratOptions: string[];
+  // Theres are columns that we want to be able to filter by but not stratifiy
+  // by. Usually these are binary thing like under 5 / all ages, you would never
+  // want to compare these values
+  filterOptions: string[];
+  // These are thing that might want to be show/hide in the UI for different
+  // versions (e.g. uncertainity)
+  uiVisible: string[];
+  // WARNING HORRIBLE HACKY CODE - REMOVE THIS EVENTUALLY
   // Other columns that are automatically filtered by but we do not let the
   // user startify by e.g. is_focal == true
-  // This should be used be sparingly as a quick fix to get a dataset to work.
+  // This should be used be sparingly as a quick hack to get a dataset to work.
   // Usually we filter the data before it gets the the app so this should be empty
   secretOptions?: { [key: string]: any };
 }

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -103,7 +103,7 @@ class DataVisModel {
   private showCohort =
     ko.observable(metricsAndOptions.methods.includes("cohort"));
   private showUncertainty =
-    ko.observable(metricsAndOptions.otherOptions.includes("uncertainty"));
+    ko.observable(metricsAndOptions.uiVisible.includes("uncertainty"));
   private showSidebar = ko.observable(true);
 
   private yearFilter = ko.observable(new RangeFilter({
@@ -113,66 +113,13 @@ class DataVisModel {
     selectedHigh: 2018,
     selectedLow: 2000,
   }));
-  private showYearFilter =
-      ko.observable(metricsAndOptions.filterOptions.includes("year"));
-
-  private activityFilter = ko.observable(new ListFilter({
-    name: "Activity",
-    options: activityTypes,
-  }));
-  private showActivityFilter =
-      ko.observable(metricsAndOptions.filterOptions.includes("activity_type"));
-
-  private countryFilter = ko.observable(new CountryFilter({
-    groups: countryGroups,
-    humanNames: countryDict,
-    name: "Country",
-    options: countries,
-    selected: countryGroups["pine"],
-  }));
-  private showCountryFilter =
-      ko.observable(metricsAndOptions.filterOptions.includes("country"));
-
-  private vaccineDiseaseFilter = ko.observable(new DiseaseFilter({
-    name: "Disease",
-    vaccineFilters: diseases.map(createVaccineFilterForDisease),
-  }));
-  private showVaccineFilter =
-      ko.observable(metricsAndOptions.filterOptions.includes("vaccine"));
-
-  private diseaseFilter = ko.observable(new ListFilter({
-    name: "Disease",
-    options: diseases,
-  }));
-  private showDiseaseFilter =
-      ko.observable(metricsAndOptions.filterOptions.includes("disease"));
-
-  private touchstoneFilter = ko.observable(new ListFilter({
-    name: "Touchstone",
-    options: touchstones,
-    selected: [initTouchstone],
-  }));
-  private showTouchstoneFilter =
-      ko.observable(metricsAndOptions.filterOptions.includes("touchstone"));
-
-  private supportFilter = ko.observable(new ListFilter({
-    name: "Gavi support",
-    humanNames: { gavi : "yes", other : "no" },
-    options: supportTypes,
-    selected: supportTypes.slice(0, 1),
-  }));
-  private showSupportFilter =
-      ko.observable(metricsAndOptions.filterOptions.includes("support_type"));
-
-  private visbleMetricButtons = ko.observableArray<string>(metricsAndOptions.metrics);
-  private showAgeGroupCheck = ko.observable(metricsAndOptions.otherOptions.includes("age_group"));
 
   private xAxisOptions =
-         metricsAndOptions.filterOptions.concat(metricsAndOptions.otherOptions);
+         metricsAndOptions.dualOptions.concat(metricsAndOptions.stratOptions);
 
   private yAxisOptions = ko.computed(() => {
     const catOptions =
-         metricsAndOptions.filterOptions.concat(metricsAndOptions.otherOptions);
+         metricsAndOptions.dualOptions.concat(metricsAndOptions.stratOptions);
     catOptions.push("none");
     switch (this.currentPlot()) {
       case "Impact":
@@ -183,6 +130,63 @@ class DataVisModel {
         return catOptions;
     }
   }, this);
+
+  private filterOptions =
+    metricsAndOptions.dualOptions.concat(metricsAndOptions.filterOptions);
+
+  private showYearFilter =
+      ko.observable(this.filterOptions.includes("year"));
+
+  private activityFilter = ko.observable(new ListFilter({
+    name: "Activity",
+    options: activityTypes,
+  }));
+  private showActivityFilter =
+      ko.observable(this.filterOptions.includes("activity_type"));
+
+  private countryFilter = ko.observable(new CountryFilter({
+    groups: countryGroups,
+    humanNames: countryDict,
+    name: "Country",
+    options: countries,
+    selected: countryGroups["pine"],
+  }));
+  private showCountryFilter =
+      ko.observable(this.filterOptions.includes("country"));
+
+  private vaccineDiseaseFilter = ko.observable(new DiseaseFilter({
+    name: "Disease",
+    vaccineFilters: diseases.map(createVaccineFilterForDisease),
+  }));
+  private showVaccineFilter =
+      ko.observable(this.filterOptions.includes("vaccine"));
+
+  private diseaseFilter = ko.observable(new ListFilter({
+    name: "Disease",
+    options: diseases,
+  }));
+  private showDiseaseFilter =
+      ko.observable(this.filterOptions.includes("disease"));
+
+  private touchstoneFilter = ko.observable(new ListFilter({
+    name: "Touchstone",
+    options: touchstones,
+    selected: [initTouchstone],
+  }));
+  private showTouchstoneFilter =
+      ko.observable(this.filterOptions.includes("touchstone"));
+
+  private supportFilter = ko.observable(new ListFilter({
+    name: "Gavi support",
+    humanNames: { gavi : "yes", other : "no" },
+    options: supportTypes,
+    selected: supportTypes.slice(0, 1),
+  }));
+  private showSupportFilter =
+      ko.observable(this.filterOptions.includes("support_type"));
+
+  private visbleMetricButtons = ko.observableArray<string>(metricsAndOptions.metrics);
+  private showAgeGroupToggle = ko.observable<boolean>(metricsAndOptions.filterOptions.includes("age_group"));
 
   private maxPlotOptions = ko.observableArray<number>(createRangeArray(1, 20));
   private maxBars = ko.observable<number>(19);

--- a/src/index.html
+++ b/src/index.html
@@ -312,7 +312,7 @@
               </div>
             </div>
 
-             <div class="btn-group mt-1" role="group">
+             <div class="btn-group mt-1" role="group" data-bind="visible: showAgeGroupToggle()">
               <button type="button" class="btn btn-primary" data-bind="click: () => changeAgeGroup('all'),
                css: {active: ageGroup() == 'all'}">All Ages
               </button>
@@ -468,7 +468,7 @@
                 </button>
               </div>
             </div>
-             <div class="btn-group mt-1" role="group">
+             <div class="btn-group mt-1" role="group" data-bind="visible: showAgeGroupToggle()">
               <button type="button" class="btn btn-primary" data-bind="click: () => changeAgeGroup('all'),
                css: {active: ageGroup() == 'all'}">All Ages
               </button>

--- a/tests/DataFilterTests.ts
+++ b/tests/DataFilterTests.ts
@@ -208,8 +208,10 @@ describe("DataFilterer", () => {
             mode: "public",
             metrics: ["deaths", "deaths_averted", "deaths_averted_rate"],
             methods: ["cross", "cohort"],
-            filterOptions: ["country", "year"],
-            otherOptions: ["continent"]
+            dualOptions: ["country", "year"],
+            stratOptions: ["continent"],
+            filterOptions: [],
+            uiVisible: []
         }
         // the functionality of this function covered in the unit testing above
         // all these tests do is make sure the main function runs without an


### PR DESCRIPTION
The mechanism we use for showing / hiding UI elements and determining what columns we can filter and/or stratify by is a json object named metricsAndOptions (probably a bad name...).

We need to make sure the values in this object agree with the columns in the dataset

This has 8 elements:
 * **mode** Is this the public or private mode for the app?
* **metrics** What numbers do we show (_e.g._ deaths, DALYs, FVPs _etc._) 
* **methods** What counting methods do we use - This doesn't relate to colums; each method has its own dataset. 
* **dualOptions** What columns can we filter **and** stratify by
* **stratOptions** What columns can we **only** stratify by
* **filterOptions** What columns can we **only** filter by
[The choice i made here was that no columns could appear in more than one list. There is an argument that dualOptions is unnecessary and we could have columns repeated in both stratOptions and filterOptions].
* **uiVisible** Used to hide / show various elements of the UI [perhaps this redundant in the with mode?]
* **secretOptions** A hacky trick to automatically filter by a column in the dataset. The dataset should be filtered before the app is compiled, but for various reasons this was difficult, so I added this to fix the problem. When I get a stable dataset from the science team this can be removed.
