### PR TITLE
Fix year ordering bug

### DIFF
--- a/src/DataFilterer.ts
+++ b/src/DataFilterer.ts
@@ -468,8 +468,15 @@ export class DataFilterer {
         const sortedCompares = sortedGroupSummed.map((d) => d[0]);
         return sortedCompares.slice(0, maxPlot);
       } else {
-        const unsortedGroupSummed = [...groupedSummed].map((d) => d[0]);
-        return unsortedGroupSummed.slice(0, maxPlot).sort();
+        // There is question around what should we do if the user is plotting
+        // year along the x axis and asks for N bars, we could either:
+        // * Show the N years with the greatest impact (treat years like all
+        //   other variables),
+        // * Show the first N years chronologically.
+        // At the moment we do the second, but there is a reasonable case for
+        // the first.
+        const unsortedGroupSummed = [...groupedSummed].map((d) => d[0]).sort();
+        return unsortedGroupSummed.slice(0, maxPlot);
       }
     } else {
       return [...new Set((impactData.map((x) => x[xAxisVar])))].sort();

--- a/tests/DataFilterTests.ts
+++ b/tests/DataFilterTests.ts
@@ -127,31 +127,41 @@ describe("DataFilterer", () => {
     it("getUniqueVariables", () => {
         const max: number = 2;
 
-        const out1: any[] = 
+        const out1: any[] =
             testObject.getUniqueVariables(max, "activity_type", "deaths_averted", fakeImpactData);
         // all of the members of compvars should be diseases
         expect(activityTypes).to.include.members(out1);
 
-        const out2: any[] = 
+        const out2: any[] =
             testObject.getUniqueVariables(max, "disease", "deaths_averted", fakeImpactData);
         // all of the members of compvars should be diseases
         expect(diseases).to.include.members(out2);
 
-        const out3: any[] = 
+        const out3: any[] =
             testObject.getUniqueVariables(max, "continent", "deaths_averted", fakeImpactData);
         // all of the members of compvars should be diseases
         expect(["Asia"]).to.include.members(out3);
 
-        const out4: any[] = 
+        const out4: any[] =
             testObject.getUniqueVariables(max, "country", "deaths_averted", fakeImpactData);
         // all of the members of compvars should be diseases
         expect(countries).to.include.members(out4);
 
 
-        const out5: any[] = 
+        const out5: any[] =
             testObject.getUniqueVariables(max, "touchstone", "deaths_averted", fakeImpactData);
         // all of the members of compvars should be diseases
         expect(touchstones).to.include.members(out5);
+
+        const out6: any[] =
+            testObject.getUniqueVariables(max, "year", "deaths_averted", fakeImpactData);
+        // all of the members of compvars should be diseases
+        expect(out6).to.include.members([2010, 2011]);
+
+        const out7: any[] =
+            testObject.getUniqueVariables(5, "year", "deaths_averted", fakeImpactData);
+        // all of the members of compvars should be diseases
+        expect([2010, 2011, 2012, 2013, 2014]).to.include.members(out7);
     })
 
     it("meanVariables", () => {


### PR DESCRIPTION
There was a bug where when requesting fewer bars on a bar chart with years along the x axes the bars were chosen more-or-less at random.

This is because we were slicing the first N then sorting, rather then sorting first.