### PR TITLE
vimc-4080 Support All Diseases and treat separately to individual diseases

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ Copy the files to `data/test`.
 1. `cd out && python -m SimpleHTTPServer` to serve the compiled files.
 1. Visit localhost:8000 in your browser to view the app.
 
+## Testing
+To run tests with coverage, run `npm run coverage`.
+

--- a/scripts/fakeVariables.ts
+++ b/scripts/fakeVariables.ts
@@ -45,7 +45,7 @@ export const countryGroups = {
 }
 
 export const diseases = ["HepB", "Hib", "HPV", "JE", "Measles", "MenA", "PCV",
-    "Rota", "Rubella", "YF", "all_diseases"];
+    "Rota", "Rubella", "YF", "All Diseases"];
 
 export const diseaseVaccines = {
     "HepB":["HepB","HepB_BD"],
@@ -57,11 +57,11 @@ export const diseaseVaccines = {
     "Rota":["Rota"],
     "Rubella":["Rubella"],
     "YF":["YF"],
-    "all_diseases": ["all_diseases_fake"]
+    "All Diseases": ["All Diseases"]
 };
 
 export const vaccines = ["HepB", "HepB_BD", "Hib3", "HPV", "JE", "MCV1", "MCV2",
-"Measles", "MenA", "PCV3", "Rota", "RCV2", "Rubella", "YF", "all_diseases_fake"];
+"Measles", "MenA", "PCV3", "Rota", "RCV2", "Rubella", "YF", "All Diseases"];
 
 export const vaccineDict = {
     HPV: "HPV",
@@ -78,7 +78,7 @@ export const vaccineDict = {
     Rota: "Rotavirus",
     Rubella: "Rubella",
     YF: "Yellow Fever",
-    all_diseases_fake: "All Diseases Fake"
+    "All Diseases": "All Diseases"
 };
 
 export const activityTypes = ["routine", "campaign", "combined"];

--- a/scripts/fakeVariables.ts
+++ b/scripts/fakeVariables.ts
@@ -57,11 +57,11 @@ export const diseaseVaccines = {
     "Rota":["Rota"],
     "Rubella":["Rubella"],
     "YF":["YF"],
-    "All Diseases": ["All Diseases"]
+    "All Diseases": ["All Vaccines"],
 };
 
 export const vaccines = ["HepB", "HepB_BD", "Hib3", "HPV", "JE", "MCV1", "MCV2",
-"Measles", "MenA", "PCV3", "Rota", "RCV2", "Rubella", "YF", "All Diseases"];
+"Measles", "MenA", "PCV3", "Rota", "RCV2", "Rubella", "YF", "All Vaccines"];
 
 export const vaccineDict = {
     HPV: "HPV",
@@ -78,7 +78,7 @@ export const vaccineDict = {
     Rota: "Rotavirus",
     Rubella: "Rubella",
     YF: "Yellow Fever",
-    "All Diseases": "All Diseases",
+    "All Vaccines": "All Vaccines",
 };
 
 export const activityTypes = ["routine", "campaign", "combined"];

--- a/scripts/fakeVariables.ts
+++ b/scripts/fakeVariables.ts
@@ -45,7 +45,7 @@ export const countryGroups = {
 }
 
 export const diseases = ["HepB", "Hib", "HPV", "JE", "Measles", "MenA", "PCV",
-    "Rota", "Rubella", "YF"];
+    "Rota", "Rubella", "YF", "all_diseases"];
 
 export const diseaseVaccines = {
     "HepB":["HepB","HepB_BD"],
@@ -56,11 +56,12 @@ export const diseaseVaccines = {
     "PCV":["PCV3"],
     "Rota":["Rota"],
     "Rubella":["Rubella"],
-    "YF":["YF"]
+    "YF":["YF"],
+    "all_diseases": ["all_diseases_fake"]
 };
 
 export const vaccines = ["HepB", "HepB_BD", "Hib3", "HPV", "JE", "MCV1", "MCV2",
-"Measles", "MenA", "PCV3", "Rota", "RCV2", "Rubella", "YF"];
+"Measles", "MenA", "PCV3", "Rota", "RCV2", "Rubella", "YF", "all_diseases_fake"];
 
 export const vaccineDict = {
     HPV: "HPV",
@@ -77,6 +78,7 @@ export const vaccineDict = {
     Rota: "Rotavirus",
     Rubella: "Rubella",
     YF: "Yellow Fever",
+    all_diseases_fake: "All Diseases Fake"
 };
 
 export const activityTypes = ["routine", "campaign", "combined"];

--- a/scripts/fakeVariables.ts
+++ b/scripts/fakeVariables.ts
@@ -78,7 +78,7 @@ export const vaccineDict = {
     Rota: "Rotavirus",
     Rubella: "Rubella",
     YF: "Yellow Fever",
-    "All Diseases": "All Diseases"
+    "All Diseases": "All Diseases",
 };
 
 export const activityTypes = ["routine", "campaign", "combined"];

--- a/scripts/generateTestData.js
+++ b/scripts/generateTestData.js
@@ -166,7 +166,8 @@ function generatePrivateData(touchstone) {
         PCV: ["PCV3"],
         Rota: ["Rota"],
         Rubella: ["RCV2", "Rubella"],
-        YF: ["YF"]
+        YF: ["YF"],
+        "All Diseases": ["All Diseases"]
     }
 
     const fakeImpactData =

--- a/scripts/generateTestData.js
+++ b/scripts/generateTestData.js
@@ -167,7 +167,7 @@ function generatePrivateData(touchstone) {
         Rota: ["Rota"],
         Rubella: ["RCV2", "Rubella"],
         YF: ["YF"],
-        "All Diseases": ["All Diseases"]
+        "All Diseases": ["All Vaccines"]
     }
 
     const fakeImpactData =

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -40,22 +40,23 @@ export interface AnnotatedChartConfiguration extends ChartConfiguration {
   options: ChartOptionsWithAnnotation;
 }
 
-export function rescaleLabel(value: number, scale: number): string {
+export function rescaleLabel(value: string | number, scale: number): string {
+  const numValue: number = typeof(value) === "string" ? parseFloat(value) : value;
   // we need to round down to three significant figures
   const df = new DataFilterer();
   if (scale > 1000000000) {
-    return df.roundDown(value, 3) / 1000000000 + "B";
+    return df.roundDown(numValue, 3) / 1000000000 + "B";
   }
   if (scale > 1000000) {
-    return df.roundDown(value, 3) / 1000000 + "M";
+    return df.roundDown(numValue, 3) / 1000000 + "M";
   }
   if (scale > 1000) {
-    return df.roundDown(value, 3) / 1000 + "K";
+    return df.roundDown(numValue, 3) / 1000 + "K";
   }
   if (scale > 1) { // round values in [1, 1000] down to nearest integer
-    return Math.floor(value) + "";
+    return Math.floor(numValue) + "";
   } // i don't think rounding x in (0,1) is a good idea need to think about this
-  return value.toString();
+  return numValue.toString();
 }
 
 export interface BaseAnnotation {

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -40,20 +40,21 @@ export interface AnnotatedChartConfiguration extends ChartConfiguration {
   options: ChartOptionsWithAnnotation;
 }
 
-export function rescaleLabel(value: string | number, scale: number): string {
+export function rescaleLabel(value: string | number, scale: string | number): string {
   const numValue: number = typeof(value) === "string" ? parseFloat(value) : value;
+  const numScale: number = typeof(scale) === "string" ? parseFloat(scale) : scale;
   // we need to round down to three significant figures
   const df = new DataFilterer();
-  if (scale > 1000000000) {
+  if (numScale > 1000000000) {
     return df.roundDown(numValue, 3) / 1000000000 + "B";
   }
-  if (scale > 1000000) {
+  if (numScale > 1000000) {
     return df.roundDown(numValue, 3) / 1000000 + "M";
   }
-  if (scale > 1000) {
+  if (numScale > 1000) {
     return df.roundDown(numValue, 3) / 1000 + "K";
   }
-  if (scale > 1) { // round values in [1, 1000] down to nearest integer
+  if (numScale > 1) { // round values in [1, 1000] down to nearest integer
     return Math.floor(numValue) + "";
   } // i don't think rounding x in (0,1) is a good idea need to think about this
   return numValue.toString();

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -193,13 +193,13 @@ export function impactChartConfig(filterData: FilteredData,
           const chart = this.chart;
           const context = chart.ctx;
           const lastDataSet: number = ds.length - 1;
-          if (lastDataSet > -1) {
+          const showBarTotals = ["disease", "vaccine"].indexOf(chartOptions.yAxis) < 0;
+          if (showBarTotals && lastDataSet > -1) {
             const lastMeta = chart.controller.getDatasetMeta(lastDataSet);
             // this is a lot of nonsense to grab the plot meta data
             // for the final (topmost) data set
             lastMeta.data.forEach( (bar: any, index: number) => {
-              const data = rescaleLabel(totals[index],
-                totals[index]);
+              const data = rescaleLabel(totals[index], totals[index]);
               // magic numbers to the labels look reasonable
               context.fillText(data, bar._model.x - 12, bar._model.y - 5);
             });
@@ -256,7 +256,7 @@ export function timeSeriesChartConfig(filterData: FilteredData,
           } else {
             meta_lo.hidden = null;
             meta.hidden = null;
-            meta_hi.hidden = null;            
+            meta_hi.hidden = null;
           }
 
           ci.update();

--- a/src/Dictionaries.ts
+++ b/src/Dictionaries.ts
@@ -18,7 +18,7 @@ export const vaccineDict: {[code: string]: string} = {
   Rota: "Rotavirus",
   Rubella: "Rubella",
   YF: "Yellow Fever",
-  "All Diseases": "All Diseases",
+  "All Vaccines": "All Vaccines",
 };
 
 export const diseaseDict: { [code: string]: string} = {

--- a/src/Dictionaries.ts
+++ b/src/Dictionaries.ts
@@ -18,6 +18,7 @@ export const vaccineDict: {[code: string]: string} = {
   Rota: "Rotavirus",
   Rubella: "Rubella",
   YF: "Yellow Fever",
+  "All Diseases": "All Diseases",
 };
 
 export const diseaseDict: { [code: string]: string} = {
@@ -31,6 +32,7 @@ export const diseaseDict: { [code: string]: string} = {
   Rota: "Rotavirus",
   Rubella: "Rubella",
   YF: "Yellow Fever",
+  "All Diseases": "All Diseases",
 };
 
 export const diseaseVaccineLookup: {[code: string]: string[]} =

--- a/src/Filter.ts
+++ b/src/Filter.ts
@@ -108,8 +108,8 @@ export class RangeFilter extends Filter {
   }
 }
 
-const allDiseases = "All Diseases";
-const allDiseasesVaccine = "All Diseases";
+export const allDiseases = "All Diseases";
+export const allDiseasesVaccine = "All Vaccines";
 export class DiseaseFilter extends ListFilter {
   private unaggregatedSelections: string[] = [];
 

--- a/src/Filter.ts
+++ b/src/Filter.ts
@@ -182,8 +182,6 @@ export class VaccineDiseaseFilter extends Filter {
       this.vaccineFilters.forEach((f) => {
         // save previously selected vaccines so we can restore later
         this.unaggregatedSelections[f.name()] = [...f.selectedOptions()];
-      });
-      this.vaccineFilters.forEach((f) => {
         f.selectedOptions(f.name() === allDiseases ? [allDiseasesVaccine] : []);
       });
     } else {

--- a/src/Filter.ts
+++ b/src/Filter.ts
@@ -108,7 +108,40 @@ export class RangeFilter extends Filter {
   }
 }
 
-export class DiseaseFilter extends Filter {
+const allDiseases = "all_diseases";
+export class DiseaseFilter extends ListFilter {
+  private individualDiseases = ko.computed(() => {
+    return this.options()
+        .filter((f) => f !== allDiseases);
+  }, this);
+
+  constructor(settings: ListFilterSettings) {
+    super(settings);
+    this.selectedOptions([...this.individualDiseases()]);
+  }
+
+  public displayDiseaseFilter = (disease: string) => disease !== allDiseases;
+
+  public get displayAggregateAll() {
+    return this.options.indexOf(allDiseases) > -1;
+  }
+
+  public get aggregateAll() {
+    return this.selectedOptions.indexOf(allDiseases) > -1;
+  }
+
+  public set aggregateAll(value) {
+    this.selectedOptions.removeAll();
+    if (value) {
+      this.selectedOptions.push(allDiseases);
+    } else {
+      this.individualDiseases()
+          .forEach((d) => this.selectedOptions.push(d));
+    }
+  }
+}
+
+export class VaccineDiseaseFilter extends Filter {
   public selectedOptions = ko.observableArray([]);
   private vaccineFilters: ListFilter[] = [];
 

--- a/src/Filter.ts
+++ b/src/Filter.ts
@@ -108,7 +108,7 @@ export class RangeFilter extends Filter {
   }
 }
 
-const allDiseases = "all_diseases";
+const allDiseases = "All Diseases";
 export class DiseaseFilter extends ListFilter {
   private individualDiseases = ko.computed(() => {
     return this.options()

--- a/src/Help.ts
+++ b/src/Help.ts
@@ -1,7 +1,7 @@
 // generate help title
 const impactOptionsHelp: string = "<p><h3>Impact Options</h3></p>" +
   "<p><h4>Compare across </h4>What values should we put along the x-axis</p>" +
-  "<p><h4>Stratify by </h4>Which variable should we use to disaggregate the bars by.</p>" +
+  "<p><h4>Stratify by </h4>Which variable should we use to disaggregate the bars by. Note that, when stratifying by disease / vaccine, we do not show total bar values, as these may be misleading due to possible double-counting.</p>" +
   "<p><h4>Max bars </h4>How many bars should we show along the x axis, this defaults to the maximum</p>" +
   "<p><h4>Metric</h4>Which impact metric to show, for more details see the metric help</p>" +
   "<p><h4>Export as...</h4>Save the data as a csv or png file. Export all provides the entire dataset as a zip file.</p>" +

--- a/src/Help.ts
+++ b/src/Help.ts
@@ -19,7 +19,7 @@ export const filterHelp: string =
   "<p><h4>Years</h4>The years for which we show the data. The meaning of the year depends on the plot method chosen.</p>" +
   "<p><h4>Activity</h4>The type of vaccination program - routine or campaign.</p>" +
   "<p><h4>Country</h4>The countries for which we show the data.</p>" +
-  "<p><h4>Disease / Vaccine</h4>The vaccines for which we show the data.</p>" +
+  "<p><h4>Disease / Vaccine</h4>The vaccines for which we show the data. Use the 'Aggregate all diseases' checkbox to show data aggregated across all diseases and vaccines to exclude double-counting.</p>" +
   "<p><h4>Touchstone</h4>The touchstone for which we show the data. This should usually be set to the latest touchstone, and selecting multiple touchstone is usually incorrect.</p>" +
   "<p><h4>Support Type</h4>Gavi vs non-Gavi vaccination programs</p>";
 

--- a/src/PlotColours.ts
+++ b/src/PlotColours.ts
@@ -18,6 +18,7 @@ export let plotColours: { [vaccine: string]: string } = {
   "Rota":    "#FCCDE5",
   "Rubella": "#D9D9D9",
   "YF":      "#BC80BD",
+  "All Diseases": "#379CC8",
   // years
   "2000":    "#0000C0",
   "2001":    "#0400BB",

--- a/src/PlotColours.ts
+++ b/src/PlotColours.ts
@@ -19,6 +19,7 @@ export let plotColours: { [vaccine: string]: string } = {
   "Rubella": "#D9D9D9",
   "YF":      "#BC80BD",
   "All Diseases": "#379CC8",
+  "All Vaccines": "#379CC8",
   // years
   "2000":    "#0000C0",
   "2001":    "#0400BB",

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -12,7 +12,7 @@ import {activityTypes, countries, countryGroups, dates, diseases, metricsAndOpti
     reportInfo, supportTypes, touchstones, vaccines} from "./Data";
 import {DataFilterer, DataFiltererOptions} from "./DataFilterer";
 import {countryDict, diseaseDict, diseaseVaccineLookup, vaccineDict} from "./Dictionaries";
-import {CountryFilter, DiseaseFilter, ListFilter, RangeFilter} from "./Filter";
+import {CountryFilter, VaccineDiseaseFilter, ListFilter, RangeFilter, DiseaseFilter} from "./Filter";
 import {filterHelp, generatedHelpBody, generatedHelpTitle, generatedMetricsHelp} from "./Help";
 import {ImpactDataRow} from "./ImpactDataRow";
 import {MetaDataDisplay} from "./MetaDataDisplay";
@@ -154,14 +154,14 @@ class DataVisModel {
   private showCountryFilter =
       ko.observable(this.filterOptions.includes("country"));
 
-  private vaccineDiseaseFilter = ko.observable(new DiseaseFilter({
+  private vaccineDiseaseFilter = ko.observable(new VaccineDiseaseFilter({
     name: "Disease",
     vaccineFilters: diseases.map(createVaccineFilterForDisease),
   }));
   private showVaccineFilter =
       ko.observable(this.filterOptions.includes("vaccine"));
 
-  private diseaseFilter = ko.observable(new ListFilter({
+  private diseaseFilter = ko.observable(new DiseaseFilter({
     name: "Disease",
     options: diseases,
   }));

--- a/src/index.html
+++ b/src/index.html
@@ -218,25 +218,36 @@
                 click: toggleOpen"></a>
 
       <div class="filter clearfix" data-bind="css: {in: isOpen}">
-        <div class="nav-item nav-option">
+        <div data-bind="if: displayAggregateAll" class="nav-item nav-option">
           <div class="nav-link">
-            <button type="button" class="btn btn-primary mt-1 btn-sm"
-                data-bind="click: () => selectAll()">All
-            </button>
-            <button type="button" class="btn btn-primary mt-1 btn-sm"
-                data-bind="click: () => selectNone()">None
-            </button>
+            <label>
+              <input type="checkbox" data-bind="checked: aggregateAll"/>
+              <span>Aggregate all diseases</span>
+            </label>
           </div>
+          <hr data-bind="visible: !aggregateAll">
         </div>
-        <hr>
-        <div data-bind="foreach: options">
+        <div data-bind="visible: !aggregateAll">
           <div class="nav-item nav-option">
             <div class="nav-link">
-              <label data-bind="attr: {for: $data}">
-                <input type="checkbox" data-bind="attr: {id: $data, value: $data},
-                  checked: $parent.selectedOptions"/>
-                <span data-bind="text: $data"></span>
-              </label>
+              <button type="button" class="btn btn-primary mt-1 btn-sm"
+                  data-bind="click: () => selectAll()">All
+              </button>
+              <button type="button" class="btn btn-primary mt-1 btn-sm"
+                  data-bind="click: () => selectNone()">None
+              </button>
+            </div>
+          </div>
+          <hr>
+          <div data-bind="foreach: options">
+            <div data-bind="if: $parent.displayDiseaseFilter($data)" class="nav-item nav-option">
+              <div class="nav-link">
+                <label data-bind="attr: {for: $data}">
+                  <input type="checkbox" data-bind="attr: {id: $data, value: $data},
+                    checked: $parent.selectedOptions"/>
+                  <span data-bind="text: $data"></span>
+                </label>
+              </div>
             </div>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -194,21 +194,33 @@
                 css: { active: isOpen },
                 click: toggleOpen"></a>
 
-      <div class="filter clearfix" data-bind="css: {in: isOpen}, foreach: vaccineFilters">
-        <div class="nav-item nav-option">
+      <div class="filter clearfix" data-bind="css: {in: isOpen}">
+        <div data-bind="if: displayAggregateAll" class="nav-item nav-option">
           <div class="nav-link">
-            <label data-bind="attr: {for: name}">
-              <span data-bind="text: makeHumanreadable(name())"></span>
-              <select multiple="multiple" class="form-control"
-                  data-bind="options: options, selectedOptions: selectedOptions,
-                    select2: { placeholder: 'Select vaccines', closeOnSelect: true }">
-              </select>
+            <label>
+              <input type="checkbox" data-bind="checked: aggregateAll"/>
+              <span>Aggregate all diseases</span>
             </label>
+          </div>
+          <hr data-bind="visible: !aggregateAll">
+        </div>
+        <div data-bind="if: !aggregateAll">
+          <div data-bind="foreach: vaccineFilters">
+            <div data-bind="if: $parent.displayVaccineFilter($data.name())" class="nav-item nav-option">
+              <div class="nav-link">
+                <label data-bind="attr: {for: name}">
+                  <span data-bind="text: makeHumanreadable(name())"></span>
+                  <select multiple="multiple" class="form-control"
+                      data-bind="options: options, selectedOptions: selectedOptions,
+                        select2: { placeholder: 'Select vaccines', closeOnSelect: true }">
+                  </select>
+                </label>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </li>
-
 
     <li class="nav-item" data-bind="with: diseaseFilter, visible: showDiseaseFilter">
       <a class="nav-link nav-parent"

--- a/src/index.html
+++ b/src/index.html
@@ -518,13 +518,21 @@
                     Cumulative
                   </label>
                 </div>
-                <div class="form-check" data-bind="visible: showUncertainty">
+                <div class="form-check" data-bind="if: showUncertainty">
                   <input class="form-check-input" type="checkbox"
                        data-bind="checked: uncertaintyChecked"
                        id="uncertaintyId">
                   <label class="form-check-label" for="uncertaintyId">
                     Show Uncertainty
                   </label>
+                  <span data-bind="with: diseaseFilter">
+                    <span data-bind="if: displayAggregateAll" >
+                      <button type="button" class="btn btn-info btn-circle"
+                              data-toggle="modal" data-target="#helpUncertaintyModal">
+                        <i class="fa fa-question-circle"></i>
+                      </button>
+                    </span>
+                  </span>
                 </div>
               </div>
             </div>
@@ -736,6 +744,31 @@
       </div>
       <div class="modal-body">
         <span data-bind="html: metaData"></span>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Uncertainty Modal -->
+<div class="modal fade" id="helpUncertaintyModal" tabindex="-1" role="dialog" aria-labelledby="uncertaintyModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="uncertaintyModalLabel">Uncertainty</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>
+          Uncertainty is approximate when multiple diseases are selected and the plot is stratified by any value other
+          than disease. This is because uncertainty is summed across each selected disease, which may result in
+          double-counting of some metrics. To see calculated uncertainty across all disease, select
+          'Aggregate all diseases' in the Disease filter.
+        </p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>

--- a/tests/ChartConfigTests.ts
+++ b/tests/ChartConfigTests.ts
@@ -59,8 +59,53 @@ describe("ChartConfigs", () => {
     expect(config.data.labels).to.eql(["a", "b", "c"]);
     expect(config.options.title.text).to.eql(c.plotTitle);
     expect(config.options.scales.yAxes[0].scaleLabel.labelString).
-      to.eql(c.yAxisTitle)
-  })
+      to.eql(c.yAxisTitle);
+
+  });
+
+  it("Check impactChartConfig bar totals labels", () => {
+      const getTotalsLabels =  (yAxis: string) => {
+          const chartOptions = {yAxis};
+          const filterData = {
+              datasets: [{}],
+              totals: [10000, 20000, 30000],
+          };
+
+          const config = impactChartConfig(filterData as any, [], chartOptions as any);
+
+          const bars = { data: [
+              {_model: {x: 100, y: 200}},
+              {_model: {x: 300, y: 400}},
+              {_model: {x: 500, y: 600}},
+           ] };
+          const generatedLabels: any[] = [];
+          const mockChart = {
+              ctx: {
+                  fillText: (text: string, x: number, y: number) => {
+                      generatedLabels.push({text, x, y});
+                  },
+              },
+              controller: {
+                  getDatasetMeta: () => {
+                      return bars;
+                  },
+              },
+          };
+          const func = config.options.animation.onComplete;
+          func.call({chart: mockChart});
+          return generatedLabels;
+      };
+      // Totals labels should not be generated for 'disease' or 'vaccine' only
+      const labelsForDisease = getTotalsLabels("disease");
+      expect(labelsForDisease.length).to.eq(0);
+      const labelsForVaccine = getTotalsLabels("vaccine");
+      expect(labelsForVaccine.length).to.eq(0);
+      const labelsForCountry = getTotalsLabels("country");
+      expect(labelsForCountry.length).to.eq(3);
+      expect(labelsForCountry[0]).to.eql({text: "10K", x: 88, y: 195});
+      expect(labelsForCountry[1]).to.eql({text: "20K", x: 288, y: 395});
+      expect(labelsForCountry[2]).to.eql({text: "30K", x: 488, y: 595});
+  });
 
   it("Check timeSeriesChartConfig", () => {
     const c: CustomChartOptions

--- a/tests/FilterTests.ts
+++ b/tests/FilterTests.ts
@@ -1,6 +1,6 @@
 import * as sinon from "sinon";
 
-import {CountryFilter, DiseaseFilter, Filter, ListFilter, RangeFilter} from "../src/Filter";
+import {CountryFilter, VaccineDiseaseFilter, Filter, ListFilter, RangeFilter} from "../src/Filter";
 import {countries, countryGroups, fakeCountryDict} from "../scripts/fakeVariables";
 import {parseIntoDictionary} from "../src/Utils";
 import {expect} from "chai";
@@ -140,7 +140,7 @@ describe("Disease-Vaccine filter", () => {
 
         const filterArray = [f1, f2, f3];
 
-        const sut = new DiseaseFilter({name: "whatever",
+        const sut = new VaccineDiseaseFilter({name: "whatever",
                                        vaccineFilters: filterArray
                                      });
 

--- a/tests/FilterTests.ts
+++ b/tests/FilterTests.ts
@@ -7,7 +7,7 @@ import {
     ListFilter,
     RangeFilter,
     DiseaseFilter,
-    allDiseases
+    allDiseases, allDiseasesVaccine
 } from "../src/Filter";
 import {countries, countryGroups, fakeCountryDict} from "../scripts/fakeVariables";
 import {parseIntoDictionary} from "../src/Utils";
@@ -193,8 +193,37 @@ describe("Disease-Vaccine filter", () => {
         const sut = new VaccineDiseaseFilter({name: "whatever",
                                        vaccineFilters: filterArray
                                      });
+        const allDiseasesFilter = new ListFilter({name: allDiseases,
+            options: [allDiseasesVaccine],
+            selected: [],
+        });
+        const sutWithAllDiseases = new VaccineDiseaseFilter({
+            name: "withAllDiseases",
+            vaccineFilters: [...filterArray, allDiseasesFilter]
+        });
 
-    it("make sure initial selection is correct", () => {
-        expect(sut.selectedOptions()).to.have.members(["aa", "bb", "ca", "cb"]);
-    });
+        it("make sure initial selection is correct", () => {
+            expect(sut.selectedOptions()).to.have.members(["aa", "bb", "ca", "cb"]);
+        });
+        it("displayVaccineFilters excludes allDiseases", () => {
+            expect(sutWithAllDiseases.displayVaccineFilter(allDiseases)).to.eq(false);
+            expect(sutWithAllDiseases.displayVaccineFilter("disease3")).to.eq(true);
+        });
+        it("displayAggregateAll is true when allDiseases is a filter", () => {
+            expect(sutWithAllDiseases.displayAggregateAll).to.eq(true);
+        });
+        it("displayAggregateAll is false when allDiseases is not a filter", () => {
+            expect(sut.displayAggregateAll).to.eq(false);
+        });
+        it("get aggregateAll returns expected result", () => {
+            expect(sutWithAllDiseases.aggregateAll).to.eq(false);
+            sutWithAllDiseases.selectedOptions([allDiseasesVaccine]);
+            expect(sutWithAllDiseases.aggregateAll).to.eq(true);
+        });
+        it("set aggregateAll saves previous selected options", () => {
+            sutWithAllDiseases.aggregateAll = true;
+            expect(sutWithAllDiseases.selectedOptions()).to.have.members([allDiseasesVaccine]);
+            sutWithAllDiseases.aggregateAll = false;
+            expect(sutWithAllDiseases.selectedOptions()).to.have.members(["aa", "bb", "ca", "cb"]);
+        });
 });

--- a/tests/FilterTests.ts
+++ b/tests/FilterTests.ts
@@ -1,6 +1,14 @@
 import * as sinon from "sinon";
 
-import {CountryFilter, VaccineDiseaseFilter, Filter, ListFilter, RangeFilter} from "../src/Filter";
+import {
+    CountryFilter,
+    VaccineDiseaseFilter,
+    Filter,
+    ListFilter,
+    RangeFilter,
+    DiseaseFilter,
+    allDiseases
+} from "../src/Filter";
 import {countries, countryGroups, fakeCountryDict} from "../scripts/fakeVariables";
 import {parseIntoDictionary} from "../src/Utils";
 import {expect} from "chai";
@@ -122,6 +130,48 @@ describe("CountryFilter", () => {
     })
 });
 
+describe("DiseaseFilter", () => {
+
+    const sut = new DiseaseFilter({
+        name: "test",
+        options: ["Rubella", "Rota", allDiseases],
+    });
+
+    const sutWithoutAllDiseases = new DiseaseFilter({
+        name: "test",
+        options: ["Rubella", "Rota"],
+    });
+
+    it("constructor initialises selectedOptions when options includes allDiseases", () => {
+        expect(sut.selectedOptions()).to.have.members([allDiseases]);
+    });
+
+    it("constructor initialises selectedOptions when options does not include allDiseases", () => {
+        expect(sutWithoutAllDiseases.selectedOptions()).to.have.members(["Rota", "Rubella"]);
+    });
+    it("displayDiseaseFilter excludes allDiseases", () => {
+        expect(sut.displayDiseaseFilter(allDiseases)).to.eq(false);
+        expect(sut.displayDiseaseFilter("Rota")).to.eq(true);
+    });
+    it("displayAggregateAll is true when allDiseases is an option", () => {
+        expect(sut.displayAggregateAll).to.eq(true);
+    });
+    it("displayAggregateAll is false when allDiseases is not an option", () => {
+        expect(sutWithoutAllDiseases.displayAggregateAll).to.eq(false);
+    });
+    it("get  aggregateAll returns expected result", () => {
+        expect(sut.aggregateAll).to.eq(true);
+        expect(sutWithoutAllDiseases.aggregateAll).to.eq(false);
+    });
+    it("set aggregateAll saves previous selected options", () => {
+        sut.selectedOptions(["Rota"]);
+        sut.aggregateAll = true;
+        expect(sut.selectedOptions()).to.have.members([allDiseases]);
+        sut.aggregateAll = false;
+        expect(sut.selectedOptions()).to.have.members(["Rota"]);
+    });
+});
+
 describe("Disease-Vaccine filter", () => {
         const f1 = new ListFilter({name: "filter1",
                                     options: ["aa", "ab", "ac"],
@@ -146,6 +196,5 @@ describe("Disease-Vaccine filter", () => {
 
     it("make sure initial selection is correct", () => {
         expect(sut.selectedOptions()).to.have.members(["aa", "bb", "ca", "cb"]);
-    })
-        
+    });
 });

--- a/tests/RescaleTests.ts
+++ b/tests/RescaleTests.ts
@@ -25,6 +25,11 @@ describe("rescaleLabels", () => {
         expect(rescaleLabel(123456, 10000)).to.equal("123K")
         expect(rescaleLabel(123456, 10000000)).to.equal("0.123M")
         expect(rescaleLabel(123456, 10000000000)).to.equal("0.000123B")
+
+        expect(rescaleLabel("123456", 0.1)).to.equal("123456");
+        expect(rescaleLabel(123456, "10000000000")).to.equal("0.000123B");
+        expect(rescaleLabel("0.1", "0.1")).to.equal("0.1");
+        expect(rescaleLabel("-1", "-1")).to.equal("-1");
     });
 
 });


### PR DESCRIPTION
First cut of the code, tested with generated test data, and the data from public: https://montagu.vaccineimpact.org/reports/report/paper-first-public-app/20200115-105913-be6fcf5b/ 
and
non public: https://montagu.vaccineimpact.org/reports/report/internal-2018-interactive-plotting/20200212-160600-673c7bc9/
May need to tweak 'All Diseases' and 'All Vaccines' in light of how Susy adds these values to the dataset. 
It should cope with old datasets without 'All Diseases' - just won't show the additional checkbox. 
And I'm not quite sure how to integrate this onto the reportle. Is it just a case of re-running the report once the data exists?