### PR TITLE
vimc-4095 set default max year to 2019

### DIFF
--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -110,7 +110,7 @@ class DataVisModel {
     max: dates["max"][0],
     min: dates["min"][0],
     name: "Years",
-    selectedHigh: 2018,
+    selectedHigh: 2019,
     selectedLow: 2000,
   }));
 

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -110,7 +110,7 @@ class DataVisModel {
     max: dates["max"][0],
     min: dates["min"][0],
     name: "Years",
-    selectedHigh: 2019,
+    selectedHigh: dates["max"][0],
     selectedLow: 2000,
   }));
 


### PR DESCRIPTION
The year range in the private app is derived from the output of another report and so can't easily be changed without amending that report:
https://github.com/vimc/montagu-reports/blob/master/src/modup2-201907/orderly.yml#L37

The year range for the public app is hard-coded, see corresponding PR:
https://github.com/vimc/montagu-reports/pull/511