### PR TITLE
vimc-4330 Metadata updates for public datavis tool

### DIFF
--- a/scripts/fakeVariables.ts
+++ b/scripts/fakeVariables.ts
@@ -85,6 +85,8 @@ export const diseaseDict = {
     Rota: "Rotavirus",
     Rubella: "Rubella",
     YF: "Yellow Fever",
+    HPV: "HPV",
+    Hib: "Hib"
 };
 
 export const activityTypes = ["routine", "campaign", "combined"];

--- a/scripts/fakeVariables.ts
+++ b/scripts/fakeVariables.ts
@@ -81,6 +81,12 @@ export const vaccineDict = {
     "All Vaccines": "All Vaccines",
 };
 
+export const diseaseDict = {
+    Rota: "Rotavirus",
+    Rubella: "Rubella",
+    YF: "Yellow Fever",
+};
+
 export const activityTypes = ["routine", "campaign", "combined"];
 
 export const plottingVariables = ["year", "country", "continent", "region",

--- a/src/MetaDataDisplay.ts
+++ b/src/MetaDataDisplay.ts
@@ -149,9 +149,10 @@ export function MetaDataDisplay(chartOptions: CustomChartOptions,
     const metaStr: string = "<p>This plot shows the " +
                 chartOptions.metric.replace("_", " ") + " data for:<br>" +
                 prettyActivities(chartOptions.activityTypes) + ";<br>" +
-                 prettyCountries(chartOptions.selectedCountries, countrydict, 4) + ";<br>" +
-                 prettyVaccines(chartOptions.selectedVaccines, vacDict, 4) + ";<br>" +
-                 prettyTouchstones(chartOptions.selectedTouchstones, 2) + ";<br>" +
+                prettyCountries(chartOptions.selectedCountries, countrydict, 4) + ";<br>" +
+                (includeVaccines ? prettyVaccines(chartOptions.selectedVaccines, vacDict, 4) + ";<br>" : "") +
+                (includeDiseases ? prettyDiseases(chartOptions.selectedDiseases, diseaseDict, 4) + ";<br>" :  "") +
+                (includeTouchstones ? prettyTouchstones(chartOptions.selectedTouchstones, 2) + ";<br>" : "") +
                  prettyYears(chartOptions.yearLow, chartOptions.yearHigh) + ";<br>" +
                  "Each line represents a " + chartOptions.yAxis + ";<br>" +
                  largest(chartOptions.maxPlot, chartOptions.xAxis) + "<\p>" +

--- a/src/MetaDataDisplay.ts
+++ b/src/MetaDataDisplay.ts
@@ -89,6 +89,20 @@ function prettyVaccines(vaccineArr: string[],
   }
 }
 
+function prettyDiseases(diseaseArr: string[],
+                        diseaseDict: { [code: string]: string },
+                        maxShow: number): string {
+  const diseaseCount: number = diseaseArr.length;
+  if (diseaseCount > maxShow) {
+    const retStr = diseaseCount.toString() + " diseases including " +
+        diseaseArr.slice(0, maxShow).map((x) => diseaseDict[x]).join(", ");
+    return retStr;
+  } else {
+    const retStr = "Diseases: " + diseaseArr.map((x) => diseaseDict[x]).join(", ");
+    return retStr;
+  }
+}
+
 function prettyTouchstones(touchstoneArr: string[], maxShow: number): string {
   const touchstoneCount: number = touchstoneArr.length;
   if (touchstoneCount > maxShow) {
@@ -112,14 +126,19 @@ function prettyActivities(activityTypes: string[]) {
 
 export function MetaDataDisplay(chartOptions: CustomChartOptions,
                                 countrydict: { [code: string]: string },
-                                vacDict: { [code: string]: string }): string {
+                                vacDict: { [code: string]: string },
+                                diseaseDict: { [code: string]: string },
+                                includeTouchstones: boolean,
+                                includeVaccines: boolean,
+                                includeDiseases: boolean): string {
   if (chartOptions.plotType === "Impact") {
     const metaStr: string = "<p>This plot shows the " +
                 chartOptions.metric.replace("_", " ") + " data for:<br>" +
                 prettyActivities(chartOptions.activityTypes) + ";<br>" +
                 prettyCountries(chartOptions.selectedCountries, countrydict, 4) + ";<br>" +
-                prettyVaccines(chartOptions.selectedVaccines, vacDict, 4) + ";<br>" +
-                prettyTouchstones(chartOptions.selectedTouchstones, 2) + ";<br>" +
+                (includeVaccines ? prettyVaccines(chartOptions.selectedVaccines, vacDict, 4) + ";<br>" : "") +
+                (includeDiseases ? prettyDiseases(chartOptions.selectedDiseases, diseaseDict, 4) + ";<br>" :  "") +
+                (includeTouchstones ? prettyTouchstones(chartOptions.selectedTouchstones, 2) + ";<br>" : "") +
                 prettyYears(chartOptions.yearLow, chartOptions.yearHigh) + ";<br>" +
                 "The data is divided up by " +
                 chartOptions.xAxis + " and " + chartOptions.yAxis + ";<br>" +

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -328,7 +328,8 @@ class DataVisModel {
   }, this).extend({rateLimit: 250});
 
   private metaData = ko.computed<string>(() => {
-    return MetaDataDisplay(this.chartOptions(), countryDict, vaccineDict);
+    return MetaDataDisplay(this.chartOptions(), countryDict, vaccineDict, diseaseDict,
+        this.showTouchstoneFilter(), this.showVaccineFilter(), this.showDiseaseFilter());
   }, this);
 
   private warningMessage = ko.computed<string>(() => {

--- a/tests/MetaDataDisplayTests.ts
+++ b/tests/MetaDataDisplayTests.ts
@@ -106,11 +106,12 @@ describe("MetaDataDisplay", () => {
         chartOptions['selectedCountries'] = ["FJI", "GMB", "GEO", "GHA", "GTM", "GIN", "GNB", "GUY", "HTI", "HND", "IND"];
         chartOptions['selectedTouchstones'] = ["ts1", "ts2"];
         chartOptions['selectedVaccines'] = ["HepB", "HepB_BD"];
+        chartOptions['selectedDiseases'] = ["Rota", "YF", "HPV", "Hib", "Rubella"];
 
         const md = MetaDataDisplay(chartOptions, dict, vaccineDict, diseaseDict, false, false, true);
         expect(md).to.not.include("Touchstones");
         expect(md).to.not.include("Vaccines");
-        expect(md).to.include("Diseases: Rotavirus, Yellow Fever");
+        expect(md).to.include("5 diseases including Rotavirus, Yellow Fever, HPV, Hib");
     });
 
     it("can exclude diseases from time series plot", () => {
@@ -125,7 +126,7 @@ describe("MetaDataDisplay", () => {
         const md = MetaDataDisplay(chartOptions, dict, vaccineDict, diseaseDict, true, true, false);
         expect(md).to.include("Touchstones");
         expect(md).to.include("Vaccines");
-        expect(md).to.not.include("Diseases: Rotavirus, Yellow Fever");
+        expect(md).to.not.include("Diseases");
     });
 });
 

--- a/tests/MetaDataDisplayTests.ts
+++ b/tests/MetaDataDisplayTests.ts
@@ -1,37 +1,42 @@
 import {CustomChartOptions} from "../src/Chart";
-import {fakeCountryDict, vaccineDict} from "../scripts/fakeVariables";
+import {fakeCountryDict, vaccineDict, diseaseDict} from "../scripts/fakeVariables";
 import {parseIntoDictionary} from "../src/Utils";
 import {MetaDataDisplay, toPlural} from "../src/MetaDataDisplay";
 import {expect} from "chai";
 
 describe("MetaDataDisplay", () => {
-    it("Check meta data", () => {
+    const testChartOptions = () => <CustomChartOptions>{
+        activityTypes: ["at1", "at2"],
+        xAxis: "cofinance_status_2018",
+        cumulative: true,
+        yAxis: "DIS",
+        hideLabels: false,
+        maxPlot: 163,
+        metric: "METRIC",
+        plotTitle: "TITLE",
+        plotType: "Impact",
+        selectedCountries: ["COD", "MMR"],
+        selectedTouchstones: ["ts1", "ts2", "ts3", "ts4", "ts5", "ts6"],
+        selectedVaccines: ["HepB", "HepB_BD", "Hib3", "HPV", "JE", "MCV1", "MCV2"],
+        selectedDiseases: ["Rota", "YF"],
+        yAxisTitle: "AXIS TITLE",
+        yearHigh: 1066,
+        yearLow: 2525,
+    };
+    const dict = parseIntoDictionary(fakeCountryDict, "country", "country_name");
+
+    it("Check error on unknown plotType", () => {
         // we don't do any error checking in MetaDataDisplay, so these fields can be gibberish
-        const chartOptions: CustomChartOptions
-            = <CustomChartOptions>{
-                activityTypes: ["at1", "at2"],
-                xAxis: "cofinance_status_2018",
-                cumulative: true,
-                yAxis: "DIS",
-                hideLabels: false,
-                maxPlot: 163,
-                metric: "METRIC",
-                plotTitle: "TITLE",
-                plotType: "TYPE",
-                selectedCountries: ["COD", "MMR"], 
-                selectedTouchstones: ["ts1", "ts2", "ts3", "ts4", "ts5", "ts6"],
-                selectedVaccines: ["HepB", "HepB_BD", "Hib3", "HPV", "JE", "MCV1", "MCV2"],
-                yAxisTitle: "AXIS TITLE",
-                yearHigh: 1066,
-                yearLow: 2525,
-            };
-        const dict = parseIntoDictionary(fakeCountryDict, "country", "country_name");
-        const md1 = MetaDataDisplay(chartOptions, dict, vaccineDict);
+        const chartOptions: CustomChartOptions = testChartOptions();
+        chartOptions.plotType = "TYPE";
+        const md1 = MetaDataDisplay(chartOptions, dict, vaccineDict, diseaseDict, true, true, true);
         expect(md1).to.be.a("string");
         expect(md1).to.include("ERROR!");
+    });
 
-        chartOptions["plotType"] = "Impact";
-        const md2 = MetaDataDisplay(chartOptions, dict, vaccineDict);
+    it("Check all metadata for Impact plot", () => {
+        const chartOptions: CustomChartOptions = testChartOptions();
+        const md2 = MetaDataDisplay(chartOptions, dict, vaccineDict, diseaseDict, true, true, true);
         expect(md2).to.be.a("string");
         expect(md2).to.include("This plot shows the");
         expect(md2).to.include("METRIC");
@@ -43,33 +48,85 @@ describe("MetaDataDisplay", () => {
         expect(md2).to.include("ts2");
         expect(md2).to.include("7 vaccines");
         expect(md2).to.include("Hepatitis B");
+        expect(md2).to.include("Diseases: Rotavirus, Yellow Fever");
         expect(md2).to.include("DR Congo");
         expect(md2).to.include("Myanmar");
         expect(md2).to.include("At2");
         expect(md2).to.include("163");
+    });
 
+    it("Check all metadata for time series plot", () => {
+        const chartOptions: CustomChartOptions = testChartOptions();
         chartOptions["plotType"] = "Time series";
         chartOptions["xAxis"] = "country";
         chartOptions["maxPlot"] = 1;
         chartOptions['selectedCountries'] = ["FJI", "GMB", "GEO", "GHA", "GTM", "GIN", "GNB", "GUY", "HTI", "HND", "IND"];
         chartOptions['selectedTouchstones'] = ["ts1", "ts2"];
         chartOptions['selectedVaccines'] = ["HepB", "HepB_BD"];
-        const md3 = MetaDataDisplay(chartOptions, dict, vaccineDict);
+
+        const md3 = MetaDataDisplay(chartOptions, dict, vaccineDict, diseaseDict, true, true, true);
         expect(md3).to.be.a("string");
         expect(md3).to.include("This plot shows the");
-        expect(md2).to.include("METRIC");
+        expect(md3).to.include("METRIC");
         expect(md3).to.include("DIS");
         expect(md3).to.include("1066");
-        expect(md2).to.include("2525");
+        expect(md3).to.include("2525");
         expect(md3).to.include("Touchstones");
         expect(md3).to.include("ts2");
         expect(md3).to.include("Vaccines");
+        expect(md3).to.include("Diseases: Rotavirus, Yellow Fever");
         expect(md3).to.include("Hepatitis B");
         expect(md3).to.include("Gambia");
         expect(md3).to.include("Ghana");
         expect(md3).to.include("At2");
         expect(md3).to.include("1");
-    })
+    });
+
+    it("can exclude touchstones and vaccines from impact plot", () => {
+        const chartOptions: CustomChartOptions = testChartOptions();
+        const md = MetaDataDisplay(chartOptions, dict, vaccineDict, diseaseDict, false, false, true);
+        expect(md).to.not.include("vaccine");
+        expect(md).to.not.include("touchstone");
+        expect(md).to.include("Diseases: Rotavirus, Yellow Fever");
+    });
+
+    it("can exclude diseases from impact plot", () => {
+        const chartOptions: CustomChartOptions = testChartOptions();
+        const md = MetaDataDisplay(chartOptions, dict, vaccineDict, diseaseDict, true, true, false);
+        expect(md).to.include("6 touchstones");
+        expect(md).to.include("7 vaccines");
+        expect(md).to.not.include("Disease");
+    });
+
+    it("can exclude touchstones and vaccines from time series plot", () => {
+        const chartOptions: CustomChartOptions = testChartOptions();
+        chartOptions["plotType"] = "Time series";
+        chartOptions["xAxis"] = "country";
+        chartOptions["maxPlot"] = 1;
+        chartOptions['selectedCountries'] = ["FJI", "GMB", "GEO", "GHA", "GTM", "GIN", "GNB", "GUY", "HTI", "HND", "IND"];
+        chartOptions['selectedTouchstones'] = ["ts1", "ts2"];
+        chartOptions['selectedVaccines'] = ["HepB", "HepB_BD"];
+
+        const md = MetaDataDisplay(chartOptions, dict, vaccineDict, diseaseDict, false, false, true);
+        expect(md).to.not.include("Touchstones");
+        expect(md).to.not.include("Vaccines");
+        expect(md).to.include("Diseases: Rotavirus, Yellow Fever");
+    });
+
+    it("can exclude diseases from time series plot", () => {
+        const chartOptions: CustomChartOptions = testChartOptions();
+        chartOptions["plotType"] = "Time series";
+        chartOptions["xAxis"] = "country";
+        chartOptions["maxPlot"] = 1;
+        chartOptions['selectedCountries'] = ["FJI", "GMB", "GEO", "GHA", "GTM", "GIN", "GNB", "GUY", "HTI", "HND", "IND"];
+        chartOptions['selectedTouchstones'] = ["ts1", "ts2"];
+        chartOptions['selectedVaccines'] = ["HepB", "HepB_BD"];
+
+        const md = MetaDataDisplay(chartOptions, dict, vaccineDict, diseaseDict, true, true, false);
+        expect(md).to.include("Touchstones");
+        expect(md).to.include("Vaccines");
+        expect(md).to.not.include("Diseases: Rotavirus, Yellow Fever");
+    });
 });
 
 describe("MetaDataDisplay", () => {


### PR DESCRIPTION
Removes touchstone from metadata display in public mode, and shows diseases rather than vaccines. 