### PR TITLE
vimc-4569 Make clearer visual distinction between paper 1 and paper2 tools

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -2,8 +2,17 @@ html, body , .page-wrapper {
     height: 100%;
 }
 
-.navbar {
+.navbar-default {
     background-color: rgba(54, 162, 235, 0.2);
+}
+
+.navbar-paper2 {
+    background-color: rgba(211, 211, 211, 0.2);
+}
+
+.navbar-info {
+    color: #0056b3;
+    max-width: 550px;
 }
 
 .sidebar {

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -112,8 +112,6 @@ class DataVisModel {
     ko.observable(metricsAndOptions.uiVisible.includes("uncertainty"));
   private showSidebar = ko.observable(true);
 
-  private paper1Embargo = ko.observable((this.mode() == "public") && (Date.now() < Date.UTC(2021, 0, 28, 23, 30)));
-
   private yearFilter = ko.observable(new RangeFilter({
     max: dates["max"][0],
     min: dates["min"][0],

--- a/src/index.html
+++ b/src/index.html
@@ -32,20 +32,25 @@
     <div class="loader"></div>
 </div>
 <div class="d-none page-wrapper" data-bind="css:{'d-none':false}">
-    <nav class="navbar navbar-light align-items-center">
+    <nav class="navbar navbar-light align-items-center" data-bind="class: mode() == 'paper2' ? 'navbar-paper2' : 'navbar-default'">
         <div style="color: #0056b3; font-size: 22px; font-weight: 500;vertical-align: -webkit-baseline-middle;">
             <a class="navbar-brand" href="https://www.vaccineimpact.org">
                 <img src="./logo-dark-drop.png" height="70px"/>
             </a>
             VIMC Data Visualisation Tool
         </div>
-        <div data-bind="visible: paper1Embargo">
-            <h3 style="color: red;">Embargoed until 23:30 (UK time) on 28 January 2021</h3>
+        <div data-bind="visible: mode() == 'public'" class="navbar-info">
+            You are viewing data from our <strong>first publication</strong><br/>
+            <a href="/2021/visualisation" target="_blank">Click here to view data from our second publication</a>
         </div>
-        <div class="small" style="color: #0056b3; max-width: 550px">
+        <div data-bind="visible: mode() == 'paper2'" class="navbar-info">
+            You are viewing data from our <strong>second publication</strong><br/>
+            <a href="/2020/visualisation" target="_blank">Click here to view data from our first publication</a>
+        </div>
+        <div class="small navbar-info">
             <div data-bind="visible: mode() == 'private'">
                 <div data-bind="text: reportId"></div>
-                <div>Data ids:
+                <div>Data ids:c
                 <a class="d-inline-block" data-bind="attr: { href: dataLink1, title: linkText }, text: dataId1"></a> /
                 <a class="d-inline-block" data-bind="attr: { href: dataLink2, title: linkText }, text: dataId2"></a>
                 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -50,7 +50,7 @@
         <div class="small navbar-info">
             <div data-bind="visible: mode() == 'private'">
                 <div data-bind="text: reportId"></div>
-                <div>Data ids:c
+                <div>Data ids:
                 <a class="d-inline-block" data-bind="attr: { href: dataLink1, title: linkText }, text: dataId1"></a> /
                 <a class="d-inline-block" data-bind="attr: { href: dataLink2, title: linkText }, text: dataId2"></a>
                 </div>


### PR DESCRIPTION
- Makes nav bar background light grey in paper 2 mode
- Shows label indicating which publication this tool is showing data for
- Adds link to the other publication's tool
- Opportunistically remove embargo notice