### PR TITLE
vimc-4641 Add report link for public tools

### DIFF
--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -205,6 +205,14 @@ class DataVisModel {
   private uncertaintyChecked = ko.observable<boolean>(false);
 
   private reportId = ko.observable<string>("Report id: " + reportInfo.rep_id);
+  private reportName = ko.observable<string>(
+      this.mode() == "public" ? "paper-first-public-app" :
+              this.mode() == "paper2" ? "paper-second-public-app" :
+                  "internal-2018-interactive-plotting"
+  );
+  private reportLink = ko.observable<string>("https://montagu.vaccineimpact.org/reports/report/"
+                        + (this.reportName()) + "/"
+                        + reportInfo.rep_id + "/");
   // if we end up with more datasets move this to arrays of ko strings
   private dataId1 = ko.observable<string>(reportInfo.dep_id[0]);
   private dataId2 = ko.observable<string>(reportInfo.dep_id[1]);

--- a/src/index.html
+++ b/src/index.html
@@ -737,6 +737,9 @@
                 </div>
             </div>
         </div>
+        <div id="footer" class="small" data-bind="visible: mode() == 'public' || mode() == 'paper2'">
+            <a href="#" data-bind="attr: { href: reportLink }, text: reportId" target="_blank"></a>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
Give visibility to report version used to generate the tool, for public tools (paper 1 and paper 2). 
This goes discreetly at the bottom of the page, unlike for private tool. 
Link to the datavis tool report only (not the dependencies) - once the dependencies view is deployed, they should easy to navigate to from the Metadata tab anyway. 