### PR TITLE
vimc-4652 Support the modified public paper 1 reportInfo json file

### DIFF
--- a/scripts/generateTestData.js
+++ b/scripts/generateTestData.js
@@ -125,6 +125,15 @@ writeToFile("data/test/reportInfo.json",
               "git_id": ["some-fake-git-id"]
             }
            );
+if (flag === "public") {
+    writeToFile("data/test/reportInfoFirstPaper.json",
+            { "rep_id": ["test-fake-id-paper-first"],
+              "dep_id": ["test-another-fake-id", "test-yet-another-fake-id"],
+              "dep_name": ["report-name", "another-report-name"],
+              "git_id": ["some-fake-git-id"]
+            }
+           );
+}
 
 writeToFile("data/test/dove94.json", countryGroups.dove94);
 writeToFile("data/test/dove96.json", countryGroups.dove96);

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -58,7 +58,8 @@ if (paper2) {
   countryGroups["vimc98"] = loadObjectFromJSONFile("./vimc98.json")
 }
 
-export const reportInfo =
-  loadObjectFromJSONFile("./reportInfo.json");
+const reportInfoFirstPaper = loadObjectFromJSONFile("./reportInfoFirstPaper.json");
+export const reportInfo = reportInfoFirstPaper.rep_id === undefined ?
+    loadObjectFromJSONFile("./reportInfo.json") : reportInfoFirstPaper;
 
 


### PR DESCRIPTION
We want to show a link to  the report id for the report used by the tool - we have been readnig this in from reportInfo.json. However because the `paper-first-public-app` report depends on reportInfo.json from its upstream report (`internal-2018-interactive-plotting`), it needs to write out the modification with its own report id as a differently named file. This will happen in [this PR](https://github.com/vimc/montagu-reports/pull/642).

This branch first tries reading in this modified file (`reportInfoFirstPaper.json`), and, if that fails, reverts to reading `reportInfo.json` (this will the case for the funders tool and paper2 tool). 

It also modifies generating test data, so that this can be tested manually locally. 