### PR TITLE
vimc-4851 Support interim update mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ report `internal-2018-interactive-plotting`.
 ## Quick start:
 This method is ideal for UI development where the data does not matter at all.
 1. `npm install`
-1. Generate completely fake data by running `npm run generate-fake-data private` or `npm run generate-fake-data public` 
-or `npm run generate-fake-data paper2` (depending on whether you want to test the private (funders), public (paper1) 
-or paper 2 app)
+1. Generate completely fake data by running one of:
+`npm run generate-fake-data [MODE]` where `[MODE]` is one of:
+- `private` - the old private (Funders') tool
+- `public` - the public tool for the first paper
+- `paper2` - the public tool for the second paper
+- `interim` - the private (Funders') tool for interim updates 
+ 
 1. `npm run build-dev` or `npm run build-dev-watch`
 1. `cd out && python -m SimpleHTTPServer` to serve the compiled files.
 1. Visit localhost:8000 in your browser to view the app.
@@ -66,3 +70,7 @@ To deploy the paper 2 app:
 1. Make sure the [report dependencies](https://github.com/vimc/montagu-reports/blob/master/src/paper-second-public-app/orderly.yml) 
 are up to date (these provide all the data that is displayed in the app)
 2. Run the report `paper-second-public-app`
+
+To deploy the interim update app:
+1. Make sure the [report dependencies](https://github.com/vimc/montagu-reports/blob/vimc-4849/src/interim-update-app/orderly.yml) are up to date (these provide all the data that is displayed in the app)
+2. Run the report `interim-update-app`

--- a/scripts/generateTestData.js
+++ b/scripts/generateTestData.js
@@ -51,6 +51,16 @@ if (flag === "public") {
         }
     });
     console.log("Fake data saved to " + fileNameYearOfVac);
+}  else if (flag === "interim") {
+    const interimPrefix = "data/test/interim_1_";
+
+    var fileNameYearOfVac = interimPrefix + "year_of_vac" + ".json";
+    fs.writeFile(fileNameYearOfVac, generateInterimData("year_of_vac", 2030, allCountries), function (err) {
+        if (err) {
+            return console.log(err);
+        }
+    });
+    console.log("Fake data saved to " + fileNameYearOfVac);
 } else if (flag === "private") {
     for (let i in touchstones) {
         var tsName = touchstones[i];
@@ -108,14 +118,16 @@ function writeToZipFile(path, lines) {
         });
 }
 
-if (flag === "paper2") {
+const paper2DataFormat = (flag === "paper2" || flag === "interim");
+
+if (paper2DataFormat) {
     writeToFile("data/test/countryCodes.json", vimc98Countries);
 } else {
     writeToFile("data/test/countryCodes.json", allCountries);
 }
 writeToFile("data/test/countryDictionary.json", fakeCountryDict);
 
-const dates = flag === "paper2" ? {"min":[2000],"max":[2030]} : {"min":[2000],"max":[2019]};
+const dates = paper2DataFormat ? {"min":[2000],"max":[2030]} : {"min":[2000],"max":[2019]};
 writeToFile("data/test/dates.json", dates);
 writeToFile("data/test/diseaseVaccines.json", diseaseVaccines);
 writeToFile("data/test/reportInfo.json",
@@ -133,7 +145,7 @@ writeToFile("data/test/gavi72.json", countryGroups.gavi72);
 writeToFile("data/test/gavi73.json", countryGroups.gavi73);
 writeToFile("data/test/gavi77.json", countryGroups.gavi77);
 writeToFile("data/test/pine5.json", countryGroups.pine);
-if (flag === "paper2") {
+if (paper2DataFormat) {
     writeToFile("data/test/vimc98.json", countryGroups.vimc98)
 } else {
     writeToFile("data/test/activities.json", activityTypes);
@@ -178,6 +190,21 @@ if (flag === "public") {
                       "stratOptions": [],
                       "filterOptions": ["age_group"],
                       "uiVisible": ["uncertainty"]
+                    }
+                   );
+} else if (flag === "interim") {
+    writeToFile("data/test/metricsAndOptions.json",
+                    {"mode": ["interim"],
+                      "touchstone": ["202107wue"],
+                      "metrics": ["deaths_averted",
+                                 "dalys_averted"],
+                      "methods": ["year_of_vac"],
+                      "dualOptions": ["country",
+                                      "year",
+                                      "disease"],
+                      "stratOptions": [],
+                      "filterOptions": ["age_group"],
+                      "uiVisible": []
                     }
                    );
 } else if (flag === "private") {
@@ -306,6 +333,49 @@ function generatePublicData(method, lastYear = 2019, countries = vimc98Countries
                             "dalys_av_lo":dalys_av - randomNumber(0, 2500),
                             "dalys_averted":dalys_av,
                             "dalys_av_hi":dalys_av + randomNumber(0, 2500),
+                        }
+                    }
+                )
+            )
+        )
+    );
+
+    return JSON.stringify(fakeImpactData);
+}
+
+function generateInterimData(method, lastYear = 2019, countries = vimc98Countries) {
+    const fakeImpactData =
+        countries.flatMap((c) =>
+            diseases.flatMap((d) =>
+                ["all", "under5"].flatMap((a) =>
+                    range(2000, lastYear).flatMap((y) => {
+                        let death_av = randomNumber(10000, 20000);
+                        let dalys_av = randomNumber(10000, 20000);
+                        return {
+                            "year": y,
+                            "disease": d,
+                            "age_group": a,
+                            "method" : method,
+                            "country": c,
+                            "country_name": `c-fullname`,
+                            "deaths_lo": "NA",
+                            "deaths": "NA",
+                            "deaths_hi": "NA",
+                            "deaths_nv_lo": "NA",
+                            "deaths_no_vac": "NA",
+                            "deaths_nv_hi": "NA",
+                            "deaths_av_lo": "NA",
+                            "deaths_averted": death_av,
+                            "deaths_av_hi": "NA",
+                            "dalys_lo": "NA",
+                            "dalys": "NA",
+                            "dalys_hi": "NA",
+                            "dalys_nv_lo": "NA",
+                            "dalys_no_vac": "NA",
+                            "dalys_nv_hi": "NA",
+                            "dalys_av_lo": "NA",
+                            "dalys_averted": dalys_av,
+                            "dalys_av_hi": "NA"
                         }
                     }
                 )

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -167,7 +167,8 @@ export function impactChartConfig(filterData: FilteredData,
           },
           stacked: true,
           ticks: {
-            callback: (value, index, values) => rescaleLabel(value, value),
+            min: 0,
+            callback: (value, index, values) => rescaleLabel(value, value)
           },
         }],
       },
@@ -279,8 +280,8 @@ export function timeSeriesChartConfig(filterData: FilteredData,
             labelString: chartOptions.yAxisTitle,
           },
           ticks: {
-            callback: (value, index, values) => rescaleLabel(value, value),
-            beginAtZero: true,
+            min: 0,
+            callback: (value, index, values) => rescaleLabel(value, value)
           },
         }],
       },

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -5,8 +5,6 @@ import {loadObjectFromJSONFile} from "./Utils";
 export const metricsAndOptions: MetricsAndOptions =
       loadObjectFromJSONFile("./metricsAndOptions.json");
 
-console.log("Mode is " +  JSON.stringify(metricsAndOptions.mode))
-
 const paper2Interface = metricsAndOptions.mode == "paper2" || metricsAndOptions.mode == "interim";
 
 export const countries: string[] =

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -5,16 +5,18 @@ import {loadObjectFromJSONFile} from "./Utils";
 export const metricsAndOptions: MetricsAndOptions =
       loadObjectFromJSONFile("./metricsAndOptions.json");
 
-const paper2 = metricsAndOptions.mode == "paper2";
+console.log("Mode is " +  JSON.stringify(metricsAndOptions.mode))
+
+const paper2Interface = metricsAndOptions.mode == "paper2" || metricsAndOptions.mode == "interim";
 
 export const countries: string[] =
   loadObjectFromJSONFile("./countryCodes.json");
 export const touchstones: string[] =
-  paper2 ? [] : loadObjectFromJSONFile("./touchstones.json");
+  paper2Interface ? [] : loadObjectFromJSONFile("./touchstones.json");
 export const supportTypes: string[] =
-  paper2 ? [] : loadObjectFromJSONFile("./support.json");
+  paper2Interface ? [] : loadObjectFromJSONFile("./support.json");
 export const activityTypes: string[] =
-  paper2 ? [] : loadObjectFromJSONFile("./activities.json");
+  paper2Interface ? [] : loadObjectFromJSONFile("./activities.json");
 
 export const disVac = loadObjectFromJSONFile("./diseaseVaccines.json");
 export const diseases: string[] = [];
@@ -54,7 +56,7 @@ export const countryGroups: { [code: string]: string[] } = {
   gavi73: loadObjectFromJSONFile("./gavi73.json"),
   gavi77: loadObjectFromJSONFile("./gavi77.json"),
 };
-if (paper2) {
+if (paper2Interface) {
   countryGroups["vimc98"] = loadObjectFromJSONFile("./vimc98.json")
 }
 

--- a/src/MetricsAndOptions.ts
+++ b/src/MetricsAndOptions.ts
@@ -1,6 +1,6 @@
 export interface MetricsAndOptions {
-  // Is this for the private or public (paper 1) or paper2 tool
-  mode: "public" | "private" | "paper2";
+  // Is this for the private or public (paper 1), paper2, or interim update tool
+  mode: "public" | "private" | "paper2" | "interim";
   // These are the metric columns in the data set e.g. deaths, dalys, cases_averted etc.
   metrics: string[];
   // These are the methods we can toggle between e.g. deaths, daly, FVPs, etc.

--- a/src/MetricsAndOptions.ts
+++ b/src/MetricsAndOptions.ts
@@ -2,7 +2,7 @@ export interface MetricsAndOptions {
   // Is this for the private or public (paper 1), paper2, or interim update tool
   mode: "public" | "private" | "paper2" | "interim";
   // Touchstone, if mode is "interim"
-  touchstone: string[];
+  touchstone?: string[];
   // These are the metric columns in the data set e.g. deaths, dalys, cases_averted etc.
   metrics: string[];
   // These are the methods we can toggle between e.g. deaths, daly, FVPs, etc.

--- a/src/MetricsAndOptions.ts
+++ b/src/MetricsAndOptions.ts
@@ -1,6 +1,8 @@
 export interface MetricsAndOptions {
   // Is this for the private or public (paper 1), paper2, or interim update tool
   mode: "public" | "private" | "paper2" | "interim";
+  // Touchstone, if mode is "interim"
+  touchstone: string[];
   // These are the metric columns in the data set e.g. deaths, dalys, cases_averted etc.
   metrics: string[];
   // These are the methods we can toggle between e.g. deaths, daly, FVPs, etc.

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -35,3 +35,32 @@ export function parseIntoDictionary(arrOfObjects: ParseDict[], lhs: string,
   }
   return outDict;
 }
+
+export function touchstoneFriendly(touchstone: string[]): string {
+  if (touchstone.length === 0 || touchstone[0].length < 7) {
+    return "";
+  }
+
+  const touchstoneName = touchstone[0];
+
+  //Expect string of the form: YYYYMMtype where type is wue or gavi
+  const year = touchstoneName.substr(0,4);
+  const monthNum = touchstoneName.substr(4,2);
+  console.log("monthNum: " + monthNum)
+  const month = Intl.DateTimeFormat('en', { month: 'long' }).format(parseInt(monthNum)); //TODO: this doesn't work, use moment instead
+  let type: string;
+  switch(touchstoneName.substr(6)) {
+    case("wue"):
+      type = "WUENIC";
+      break;
+    case("gavi"):
+      type = "OP";
+      break;
+    default:
+      type = "";
+      break;
+  }
+  const result = `${month} ${year} ${type}`;
+  console.log("friendly ts: " + result);
+  return result;
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,4 +1,5 @@
 import * as $ from "jquery";
+import * as moment from "moment";
 
 export function loadObjectFromJSONFile(path: string): any {
   let newData: {[code: string]: string[]} = {}; // fail safe in case the file can't be read
@@ -36,31 +37,39 @@ export function parseIntoDictionary(arrOfObjects: ParseDict[], lhs: string,
   return outDict;
 }
 
-export function touchstoneFriendly(touchstone: string[]): string {
-  if (touchstone.length === 0 || touchstone[0].length < 7) {
+export function touchstoneFriendly(touchstone: string[] | undefined): string {
+  if (!touchstone || touchstone.length === 0) {
     return "";
   }
 
   const touchstoneName = touchstone[0];
 
+  if (touchstoneName.length < 7) {
+    return touchstoneName;
+  }
+
   //Expect string of the form: YYYYMMtype where type is wue or gavi
   const year = touchstoneName.substr(0,4);
-  const monthNum = touchstoneName.substr(4,2);
-  console.log("monthNum: " + monthNum)
-  const month = Intl.DateTimeFormat('en', { month: 'long' }).format(parseInt(monthNum)); //TODO: this doesn't work, use moment instead
-  let type: string;
-  switch(touchstoneName.substr(6)) {
-    case("wue"):
-      type = "WUENIC";
-      break;
-    case("gavi"):
-      type = "OP";
-      break;
-    default:
-      type = "";
-      break;
+  const monthNum = parseInt(touchstoneName.substr(4,2));
+
+  //Bail out and return the string unchanged if cannot parse the month part as numeric
+  if (isNaN(monthNum)) {
+    return touchstoneName
+  } else {
+    const month = moment.months(monthNum - 1);
+    const type = touchstoneName.substr(6);
+    let friendlyType: string;
+    switch (type) {
+      case("wue"):
+        friendlyType = "WUENIC";
+        break;
+      case("gavi"):
+        friendlyType = "OP";
+        break;
+      default:
+        friendlyType = type;
+        break;
+    }
+    return `${month} ${year} ${friendlyType}`;
   }
-  const result = `${month} ${year} ${type}`;
-  console.log("friendly ts: " + result);
-  return result;
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -10,6 +10,10 @@ html, body , .page-wrapper {
     background-color: rgba(144,238,144, 0.4)
 }
 
+.navbar-interim {
+    background-color: rgba(250, 195, 127, 0.8)
+}
+
 .navbar-info {
     color: #0056b3;
     max-width: 550px;

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -25,7 +25,16 @@ let initTouchstone: string = "Uninitialized initTouchstone";
 let montaguDataSets: DataSet[] = [];
 let initMethod: string = "Uninitialized initMethod";
 
-if (metricsAndOptions.mode.includes("public") || metricsAndOptions.mode.includes("paper2")) {
+if (metricsAndOptions.mode.includes("interim")) {
+  filePrefix = "interim";
+  initTouchstone = "1";
+  initMethod = "year_of_vac";
+  montaguDataSets = [
+    { name : "year_of_vac", data : [], seen : [], selected: [] }
+  ];
+  appendToDataSet(["1"], filePrefix, "year_of_vac", montaguDataSets, true);
+
+} else if (metricsAndOptions.mode.includes("public") || metricsAndOptions.mode.includes("paper2")) {
   filePrefix = metricsAndOptions.mode.includes("public") ? "firstPaper" : "secondPaper";
   initTouchstone = "1";
   initMethod = "cross";
@@ -95,12 +104,15 @@ class DataVisModel {
   };
   private currentPlot = ko.observable("Impact");
 
-  private mode = ko.observable(metricsAndOptions.mode);
+  private mode = ko.observable(metricsAndOptions.mode.toString());
+  //private touchstone = ko.observable(metricsAndOptions.touchstone.toString());
 
   private impactData = ko.observable(getDataSet(initMethod, montaguDataSets).data);
   private yearMethod = ko.observable(initMethod);
 
   private logo = ko.observable(this.mode() == "paper2" ? "./logo-green-drop.png" : "./logo-dark-drop.png");
+  private navbarClass = ko.observable(["paper2", "interim"].includes(this.mode()) ? `navbar-${this.mode()}` : "navbar-default");
+
   private plotColours =
       ko.observable(this.mode() == "private" ? {...plotColours, ...legacyColours} : plotColours);
 

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -17,6 +17,7 @@ import {filterHelp, generatedHelpBody, generatedHelpTitle, generatedMetricsHelp}
 import {ImpactDataRow} from "./ImpactDataRow";
 import {MetaDataDisplay} from "./MetaDataDisplay";
 import {plotColours, legacyColours} from "./PlotColours";
+import {touchstoneFriendly} from "./Utils";
 import {WarningMessageManager} from "./WarningMessage";
 
 // stuff to handle the data set being split into multiple files
@@ -105,7 +106,7 @@ class DataVisModel {
   private currentPlot = ko.observable("Impact");
 
   private mode = ko.observable(metricsAndOptions.mode.toString());
-  //private touchstone = ko.observable(metricsAndOptions.touchstone.toString());
+  private touchstoneName = ko.observable(this.mode() == "interim" ? touchstoneFriendly(metricsAndOptions.touchstone) : null);
 
   private impactData = ko.observable(getDataSet(initMethod, montaguDataSets).data);
   private yearMethod = ko.observable(initMethod);

--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -208,7 +208,7 @@ class DataVisModel {
   private visbleMetricButtons = ko.observableArray<string>(metricsAndOptions.metrics);
   private showAgeGroupToggle = ko.observable<boolean>(metricsAndOptions.filterOptions.includes("age_group"));
 
-  private maxBars = ko.observable<number>(this.mode() == 'paper2' ? 31 : 20);
+  private maxBars = ko.observable<number>(["paper2", "interim"].includes(this.mode()) ? 31 : 20);
   private maxPlotOptions = ko.observableArray<number>(createRangeArray(1, this.maxBars()));
 
   private xAxis = ko.observable<string>(this.xAxisOptions[1]);
@@ -221,6 +221,7 @@ class DataVisModel {
   private reportName = ko.observable<string>(
       this.mode() == "public" ? "paper-first-public-app" :
               this.mode() == "paper2" ? "paper-second-public-app" :
+               this.mode() == "interim" ? "interim-update-app" :
                   "internal-2018-interactive-plotting"
   );
   private reportLink = ko.observable<string>("https://montagu.vaccineimpact.org/reports/report/"

--- a/src/index.html
+++ b/src/index.html
@@ -48,7 +48,7 @@
             <a href="/2020/visualisation" target="_blank">Click here to view data from our first publication</a>
         </div>
         <div data-bind="visible: mode() == 'interim'" class="navbar-info">
-            You are viewing data from our <strong>2021 interim update</strong><br/>
+            You are viewing data from our <strong><span data-bind="text: touchstoneName"></span> interim update</strong><br/>
             <a href="/2021/visualisation" target="_blank">Click here to view data from our second publication</a>
         </div>
         <div class="small navbar-info">
@@ -67,7 +67,7 @@
                 <a href="https://www.vaccineimpact.org">More information about VIMC</a><br/>
                 <a href="https://doi.org/10.1016/S0140-6736(20)32657-X" target="_blank">Read the publication underlying these estimates</a>
             </span>
-            <span  data-bind="visible: mode() == 'paper2'">
+            <span  data-bind="visible: mode() == 'paper2' || mode() == 'interim'">
                 This tool shows the Vaccine Impact Modelling Consortium's estimates of health impact from vaccination
                 against
                 10 pathogens in 112 low and middle income countries from 2000 to 2030. <br/>

--- a/src/index.html
+++ b/src/index.html
@@ -32,7 +32,7 @@
     <div class="loader"></div>
 </div>
 <div class="d-none page-wrapper" data-bind="css:{'d-none':false}">
-    <nav class="navbar navbar-light align-items-center" data-bind="class: mode() == 'paper2' ? 'navbar-paper2' : 'navbar-default'">
+    <nav class="navbar navbar-light align-items-center" data-bind="class: navbarClass()">
         <div style="color: #0056b3; font-size: 22px; font-weight: 500;vertical-align: -webkit-baseline-middle;">
             <a class="navbar-brand" href="https://www.vaccineimpact.org">
                 <img data-bind="attr:{src: logo} " height="70px"/>
@@ -46,6 +46,10 @@
         <div data-bind="visible: mode() == 'paper2'" class="navbar-info">
             You are viewing data from our <strong>second publication</strong><br/>
             <a href="/2020/visualisation" target="_blank">Click here to view data from our first publication</a>
+        </div>
+        <div data-bind="visible: mode() == 'interim'" class="navbar-info">
+            You are viewing data from our <strong>2021 interim update</strong><br/>
+            <a href="/2021/visualisation" target="_blank">Click here to view data from our second publication</a>
         </div>
         <div class="small navbar-info">
             <div data-bind="visible: mode() == 'private'">
@@ -737,7 +741,7 @@
                 </div>
             </div>
         </div>
-        <div id="footer" class="small" data-bind="visible: mode() == 'public' || mode() == 'paper2'">
+        <div id="footer" class="small" data-bind="visible: ['public', 'paper2', 'interim'].includes(mode())">
             <a href="#" data-bind="attr: { href: reportLink }, text: reportId" target="_blank"></a>
         </div>
     </div>

--- a/tests/ChartConfigTests.ts
+++ b/tests/ChartConfigTests.ts
@@ -60,6 +60,7 @@ describe("ChartConfigs", () => {
     expect(config.options.title.text).to.eql(c.plotTitle);
     expect(config.options.scales.yAxes[0].scaleLabel.labelString).
       to.eql(c.yAxisTitle);
+    expect(config.options.scales.yAxes[0].ticks.min).to.eq(0);
 
   });
 
@@ -138,6 +139,7 @@ describe("ChartConfigs", () => {
     expect(config.options.title.text).to.eql(c.plotTitle);
     expect(config.options.scales.yAxes[0].scaleLabel.labelString).
       to.eql(c.yAxisTitle)
+    expect(config.options.scales.yAxes[0].ticks.min).to.eq(0);
   })
 });
 

--- a/tests/UtilsTests.ts
+++ b/tests/UtilsTests.ts
@@ -12,7 +12,7 @@ describe("touchstoneFriendly", () => {
     });
 
     it("returns unchanged touchstone if month part is not numeric", () => {
-        expect(touchstoneFriendly(["2020Q1test"])).to.eq("2021Q1test");
+        expect(touchstoneFriendly(["2021Q1test"])).to.eq("2021Q1test");
     });
 
     it("returns friendly touchstone name for WUENIC touchstone", () => {

--- a/tests/UtilsTests.ts
+++ b/tests/UtilsTests.ts
@@ -1,0 +1,29 @@
+import {expect} from "chai";
+import {touchstoneFriendly} from "../src/Utils";
+
+describe("touchstoneFriendly", () => {
+    it("returns empty string if no touchstone provided", () => {
+        expect(touchstoneFriendly(undefined)).to.eq("");
+        expect(touchstoneFriendly([])).to.eq("");
+    });
+
+    it("returns unchanged touchstone if shorter than expected", () => {
+        expect(touchstoneFriendly(["test"])).eq("test");
+    });
+
+    it("returns unchanged touchstone if month part is not numeric", () => {
+        expect(touchstoneFriendly(["2020Q1test"])).to.eq("2021Q1test");
+    });
+
+    it("returns friendly touchstone name for WUENIC touchstone", () => {
+        expect(touchstoneFriendly(["202110wue"])).to.eq("October 2021 WUENIC");
+    });
+
+    it("returns friendly touchstone name for OP touchstone", () => {
+        expect(touchstoneFriendly(["202001gavi"])).to.eq("January 2020 OP");
+    });
+
+    it("returns unchanged type for unknown touchstone type", () => {
+        expect(touchstoneFriendly(["202212test"])).to.eq("December 2022 test");
+    });
+});


### PR DESCRIPTION
This PR and [the one for the report](https://github.com/vimc/montagu-reports/pull/730) which supports it are somewhat interdependent (the report packages the typescript, while the typescript expects the data generated by the report), but this one can go first, since it can at least be tested with test data not directly from the report. However see [attached zip](https://github.com/vimc/ts_data_visualisation/files/7130398/interim.app.data.zip), for data which was generated from running the new report (by me, locally, using dependencies from production). You can test with this as described in 'Using real data' in the README. 

This branch adds a further 'mode', `interim`, in which the Typescript app can run, in addition to the existing modes (`private`, `public` (i.e. public paper 1 tool), `paper2`). Mode is identified in the `metricsAndOptions.json` configuration file which is generated by the report. 

In this mode:
- only `yearOfVac` method is expected, not `cohort` or `cross`, and only deaths averted and DALYs averted metrics (central estimates only, no low or high values). 
- `touchstone` is expected to be provided in `metricsAndOptions.json`, and a friendly name for the touchstone is displayed in the header, along with an indication that this is interim data e.g. '202107wue` -> "You are viewing data from our July 2021 WUENIC interim update"
- Header background colour is apricot
- The UI in all other respects is identical to that for paper 2, including report id in footer, and header text on right ("This tool shows..")

The link to the report dependencies in the README should be updated to the master branch once the report PR is merged.

Changes have been made to `generateTestData.js` to enable creation of fake interim data with expected format and config. 

Test coverage is limited in this repository - I've just added tests for the new utils method. 