### PR TITLE
vimc-4863 Hide paper link in interim mode

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -72,7 +72,8 @@
                 against
                 10 pathogens in 112 low and middle income countries from 2000 to 2030. <br/>
                 <a href="https://www.vaccineimpact.org">More information about VIMC</a><br/>
-                <a href="https://elifesciences.org/articles/67635" target="_blank">Read the publication underlying these estimates</a>
+                <a data-bind="visible: mode() == 'paper2'"
+                   href="https://elifesciences.org/articles/67635" target="_blank">Read the publication underlying these estimates</a>
             </span>
         </div>
     </nav>


### PR DESCRIPTION
Link to 'Read the publication underlying these estimates' should be hidden in interim mode, as there is no publication associated with the update. The other right-hand header info (number of countries etc) remains the same as for paper 2.
