### PR TITLE
vimc-4871 Change titles of figures in interim mode

### DIFF
--- a/src/data_vis.ts
+++ b/src/data_vis.ts
@@ -584,14 +584,14 @@ class DataVisModel {
         return "DALYS between " + this.yearFilter().selectedLow() +
              " and " + this.yearFilter().selectedHigh();
       case "deaths_averted":
-        return "Deaths averted between " + this.yearFilter().selectedLow() +
-            " and " + this.yearFilter().selectedHigh();
+        return this.mode() === "interim" ? "Deaths averted by year of vaccination" :
+            "Deaths averted between " + this.yearFilter().selectedLow() + " and " + this.yearFilter().selectedHigh();
       case "cases_averted":
         return "Cases averted between " + this.yearFilter().selectedLow() +
             " and " + this.yearFilter().selectedHigh();
       case "dalys_averted":
-        return "DALYS averted between " + this.yearFilter().selectedLow() +
-            " and " + this.yearFilter().selectedHigh();
+        return this.mode() === "interim" ? "DALYS averted by year of vaccination" :
+            "DALYS averted between " + this.yearFilter().selectedLow() + " and " + this.yearFilter().selectedHigh();
       case "fvps":
         return "fvps between " + this.yearFilter().selectedLow() +
              " and " + this.yearFilter().selectedHigh();


### PR DESCRIPTION
As suggested by Jaspreet, this updates figure title "Deaths averted between 2000 and 2030" to "Deaths averted by year of vaccination", and "DALYS averted between 2000 and 2030" to DALYS averted by year of vaccination" when the tool is in 'interim' mode.