### PR TITLE
Fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This method is ideal for UI development where the data does not matter at all.
 - `interim` - the private (Funders') tool for interim updates 
  
 1. `npm run build-dev` or `npm run build-dev-watch`
-1. `cd out && python -m SimpleHTTPServer` to serve the compiled files.
+1. `cd out && python3 -m http.server` to serve the compiled files.
 1. Visit localhost:8000 in your browser to view the app.
 
 Note that the fake data only contains points for the most recent 3 touchstones.
@@ -45,7 +45,7 @@ report on the reporting portal
 Copy the files to `data/test`.
 1. `npm install`
 1. `npm run build-dev` or `npm run build-dev-watch`
-1. `cd out && python -m SimpleHTTPServer` to serve the compiled files.
+1. `cd out && python3 -m http.server` to serve the compiled files.
 1. Visit localhost:8000 in your browser to view the app.
 
 ## Testing

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {},
   "devDependencies": {
     "@types/chai": "^4.2.6",
     "@types/chart.js": "^2.9.9",
@@ -52,7 +51,6 @@
     "@types/file-saver": "^2.0.1",
     "@types/jquery": "^3.3.31",
     "@types/json2csv": "^4.5.0",
-    "@types/leaflet": "^1.5.6",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.15",
     "@types/sinon": "^7.5.1",

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -163,9 +163,6 @@ ul.countries-list {
     box-shadow: inset 0 0 0 0 rgba(0,0,0,.4),-2px -3px 5px -2px rgba(0,0,0,.4);
 }
 
-/* Used for leaflet */
-.mapid { height: 180px; }
-
 .select2-container--default.select2-container--focus .select2-selection--multiple {
     border-color: #80bdff !important;
     box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);


### PR DESCRIPTION
Remove broken leaflet types dependency. This was causing the build to fail. I don't really know why it was in there - maybe we had a map view in the tool initially? Annotate says James added it in 2019!

Also updated README for newer http server for local dev. 